### PR TITLE
Use collection interfaces instead of concrete classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ import org.typesense.resources.*;
 
 ### Create a new client
 ```java
-ArrayList<Node> nodes = new ArrayList<>();
+List<Node> nodes = new ArrayList<>();
 nodes.add(
   new Node(
     "http",       // For Typesense Cloud use https
@@ -40,7 +40,7 @@ Client client = new Client(configuration);
 
 ### Create a new collection
 ```java
-ArrayList<Field> fields = new ArrayList<>();
+List<Field> fields = new ArrayList<>();
 fields.add(new Field().name("countryName").type(FieldTypes.STRING));
 fields.add(new Field().name("capital").type(FieldTypes.STRING));
 fields.add(new Field().name("gdp").type(FieldTypes.INT32).facet(true).sort(true));
@@ -53,7 +53,7 @@ client.collections().create(collectionSchema);
 
 ### Index a document
 ```java
-HashMap<String, Object> hmap = new HashMap<>();
+Map<String, Object> hmap = new HashMap<>();
 hmap.put("countryName","India");
 hmap.put("capital","Delhi");
 hmap.put("gdp", 10);
@@ -63,7 +63,7 @@ client.collections("contryName").documents().create(hmap);
 
 ### Upserting a document
 ```java
-HashMap<String, Object> hmap = new HashMap<>();
+Map<String, Object> hmap = new HashMap<>();
 hmap.put("countryName","India");
 hmap.put("capital","Delhi");
 hmap.put("gdp", 5);
@@ -93,7 +93,7 @@ SearchResult searchResult = client.collections("countries").documents().search(s
 
 ### Update a document
 ```java
-HashMap<String, Object> hmap = new HashMap<>();
+Map<String, Object> hmap = new HashMap<>();
 hmap.put("gdp", 8);
 client.collections("countries").documents("28").update(hmap);
 ```
@@ -268,7 +268,7 @@ client.collections("countries").synonyms("continent-synonyms").delete();
 
 ### Create snapshot (for backups)
 ```java
-HashMap<String, String> query = new HashMap<>();
+Map<String, String> query = new HashMap<>();
 query.put("snapshot_path","/tmp/typesense-data-snapshot");
 
 client.operations.perform("snapshot",query);

--- a/src/main/java/org/typesense/api/Client.java
+++ b/src/main/java/org/typesense/api/Client.java
@@ -1,6 +1,7 @@
 package org.typesense.api;
 
 import java.util.HashMap;
+import java.util.Map;
 
 public class Client {
     private Configuration configuration;
@@ -8,13 +9,13 @@ public class Client {
     private ApiCall apiCall;
 
     private Collections collections;
-    private HashMap<String, Collection> individualCollections;
+    private Map<String, Collection> individualCollections;
 
     private Aliases aliases;
-    private HashMap<String, Alias> individualAliases;
+    private Map<String, Alias> individualAliases;
 
     private Keys keys;
-    private HashMap<Long, Key> individualKeys;
+    private Map<Long, Key> individualKeys;
 
     public Health health;
     public Operations operations;
@@ -30,7 +31,7 @@ public class Client {
         this.aliases = new Aliases(this.apiCall);
         this.individualAliases = new HashMap<>();
         this.keys = new Keys(this.apiCall);
-        this.individualKeys = new HashMap<Long, Key>();
+        this.individualKeys = new HashMap<>();
         this.health = new Health(this.apiCall);
         this.operations = new Operations(this.apiCall);
         this.metrics = new Metrics(this.apiCall);

--- a/src/main/java/org/typesense/api/Collection.java
+++ b/src/main/java/org/typesense/api/Collection.java
@@ -4,6 +4,7 @@ import org.typesense.model.CollectionResponse;
 import org.typesense.model.CollectionUpdateSchema;
 
 import java.util.HashMap;
+import java.util.Map;
 
 public class Collection {
 
@@ -14,13 +15,13 @@ public class Collection {
     private final String name;
 
     private Documents documents;
-    private HashMap<String, Document> individualDocuments;
+    private Map<String, Document> individualDocuments;
 
     private Synonyms synonyms;
-    private HashMap<String, Synonym> individualSynonyms;
+    private Map<String, Synonym> individualSynonyms;
 
     private Overrides overrides;
-    private HashMap<String, Override> individualOverrides;
+    private Map<String, Override> individualOverrides;
 
     private final String endpoint;
 
@@ -30,11 +31,11 @@ public class Collection {
         this.configuration = configuration;
         this.endpoint = Collections.RESOURCE_PATH + "/" + this.name;
         this.documents = new Documents(this.name, this.apiCall, this.configuration);
-        this.individualDocuments = new HashMap<String, Document>();
+        this.individualDocuments = new HashMap<>();
         this.synonyms = new Synonyms(this.name, this.apiCall);
-        this.individualSynonyms = new HashMap<String, Synonym>();
+        this.individualSynonyms = new HashMap<>();
         this.overrides = new Overrides(this.name, this.apiCall);
-        this.individualOverrides = new HashMap<String, Override>();
+        this.individualOverrides = new HashMap<>();
     }
 
     public CollectionResponse retrieve() throws Exception {

--- a/src/main/java/org/typesense/api/Debug.java
+++ b/src/main/java/org/typesense/api/Debug.java
@@ -1,6 +1,6 @@
 package org.typesense.api;
 
-import java.util.HashMap;
+import java.util.Map;
 
 public class Debug {
 
@@ -11,7 +11,7 @@ public class Debug {
         this.apiCall = apiCall;
     }
 
-    public HashMap<String, String> retrieve() throws Exception {
-        return this.apiCall.get(RESOURCEPATH, null, HashMap.class);
+    public Map<String, String> retrieve() throws Exception {
+        return this.apiCall.get(RESOURCEPATH, null, Map.class);
     }
 }

--- a/src/main/java/org/typesense/api/Document.java
+++ b/src/main/java/org/typesense/api/Document.java
@@ -1,6 +1,6 @@
 package org.typesense.api;
 
-import java.util.HashMap;
+import java.util.Map;
 
 public class Document {
     private String collectionName;
@@ -16,16 +16,16 @@ public class Document {
         this.endpoint = Collections.RESOURCE_PATH + "/" +  this.collectionName + Documents.RESOURCE_PATH + "/" + this.documentId;
     }
 
-    public HashMap<String,Object> retrieve() throws Exception {
-        return this.apiCall.get(endpoint, null, HashMap.class);
+    public Map<String,Object> retrieve() throws Exception {
+        return this.apiCall.get(endpoint, null, Map.class);
     }
 
-    public HashMap<String, Object> delete() throws Exception {
-        return this.apiCall.delete(this.endpoint, null, HashMap.class);
+    public Map<String, Object> delete() throws Exception {
+        return this.apiCall.delete(this.endpoint, null, Map.class);
     }
 
-    public HashMap<String , Object> update(HashMap<String, Object> document) throws Exception {
-        return this.apiCall.patch(this.endpoint, document, null, HashMap.class);
+    public Map<String , Object> update(Map<String, Object> document) throws Exception {
+        return this.apiCall.patch(this.endpoint, document, null, Map.class);
     }
 
 }

--- a/src/main/java/org/typesense/api/Documents.java
+++ b/src/main/java/org/typesense/api/Documents.java
@@ -3,8 +3,7 @@ package org.typesense.api;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.typesense.model.*;
 
-import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.Map;
 
 public class Documents {
 
@@ -20,31 +19,31 @@ public class Documents {
         this.configuration = configuration;
     }
 
-    public HashMap<String, Object> create(HashMap<String, Object> document) throws Exception {
-        return this.apiCall.post(getEndPoint("/"), document, null, HashMap.class);
+    public Map<String, Object> create(Map<String, Object> document) throws Exception {
+        return this.apiCall.post(getEndPoint("/"), document, null, Map.class);
     }
 
     public String create(String document) throws Exception {
         return this.apiCall.post(getEndPoint("/"),document,null,String.class);
     }
 
-    public String create(HashMap<String, Object> document, ImportDocumentsParameters queryParameters) throws Exception {
+    public String create(Map<String, Object> document, ImportDocumentsParameters queryParameters) throws Exception {
         return this.apiCall.post(getEndPoint("/"),document,queryParameters,String.class);
     }
 
-    public HashMap<String, Object> upsert(HashMap<String, Object> document) throws Exception {
+    public Map<String, Object> upsert(Map<String, Object> document) throws Exception {
         ImportDocumentsParameters queryParameters = new ImportDocumentsParameters();
         queryParameters.action("upsert");
 
-        return this.apiCall.post(getEndPoint("/"),document,queryParameters,HashMap.class);
+        return this.apiCall.post(getEndPoint("/"),document,queryParameters,Map.class);
     }
 
     public SearchResult search(SearchParameters searchParameters) throws Exception {
         return this.apiCall.get(getEndPoint("search"),  searchParameters,org.typesense.model.SearchResult.class);
     }
 
-    public HashMap<String, Object> delete(DeleteDocumentsParameters queryParameters) throws Exception {
-        return this.apiCall.delete(getEndPoint("/"), queryParameters, HashMap.class);
+    public Map<String, Object> delete(DeleteDocumentsParameters queryParameters) throws Exception {
+        return this.apiCall.delete(getEndPoint("/"), queryParameters, Map.class);
     }
 
     public String export() throws Exception {
@@ -59,11 +58,10 @@ public class Documents {
             return this.apiCall.post(this.getEndPoint("import"),document, queryParameters,String.class);
     }
 
-    public String import_(ArrayList<HashMap<String, Object>> documents, ImportDocumentsParameters queryParameters) throws Exception {
+    public String import_(java.util.Collection<Map<String, Object>> documents, ImportDocumentsParameters queryParameters) throws Exception {
         ObjectMapper mapper = new ObjectMapper();
         String json="";
-        for(int i=0;i<documents.size();i++){
-            HashMap<String, Object> document = documents.get(i);
+        for(Map<String, Object> document : documents){
             try {
                 //Convert Map to JSON
                 json = json.concat(mapper.writeValueAsString(document) + "\n");

--- a/src/main/java/org/typesense/api/Health.java
+++ b/src/main/java/org/typesense/api/Health.java
@@ -1,6 +1,6 @@
 package org.typesense.api;
 
-import java.util.HashMap;
+import java.util.Map;
 
 public class Health {
 
@@ -11,7 +11,7 @@ public class Health {
         this.apiCall = apiCall;
     }
 
-    public HashMap<String, Object> retrieve() throws Exception {
-        return this.apiCall.get(RESOURCEPATH, null, HashMap.class);
+    public Map<String, Object> retrieve() throws Exception {
+        return this.apiCall.get(RESOURCEPATH, null, Map.class);
     }
 }

--- a/src/main/java/org/typesense/api/Keys.java
+++ b/src/main/java/org/typesense/api/Keys.java
@@ -10,7 +10,7 @@ import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
-import java.util.HashMap;
+import java.util.Map;
 
 public class Keys {
 
@@ -32,7 +32,7 @@ public class Keys {
         return this.apiCall.get(Keys.RESOURCEPATH, null, ApiKeysResponse.class);
     }
 
-    public String generateScopedSearchKey(String searchKey, HashMap<String, Object> parameters){
+    public String generateScopedSearchKey(String searchKey, Map<String, Object> parameters){
         ObjectMapper mapper = new ObjectMapper();
         String params = "";
         try {

--- a/src/main/java/org/typesense/api/Metrics.java
+++ b/src/main/java/org/typesense/api/Metrics.java
@@ -1,6 +1,6 @@
 package org.typesense.api;
 
-import java.util.HashMap;
+import java.util.Map;
 
 public class Metrics {
 
@@ -11,7 +11,7 @@ public class Metrics {
         this.apiCall = apiCall;
     }
 
-    public HashMap<String, String> retrieve() throws Exception {
-        return this.apiCall.get(RESOURCEPATH, null, HashMap.class);
+    public Map<String, String> retrieve() throws Exception {
+        return this.apiCall.get(RESOURCEPATH, null, Map.class);
     }
 }

--- a/src/main/java/org/typesense/api/MultiSearch.java
+++ b/src/main/java/org/typesense/api/MultiSearch.java
@@ -2,7 +2,7 @@ package org.typesense.api;
 
 import org.typesense.model.MultiSearchResponse;
 
-import java.util.HashMap;
+import java.util.Map;
 import java.util.List;
 
 public class MultiSearch {
@@ -14,7 +14,7 @@ public class MultiSearch {
         this.apiCall = apiCall;
     }
 
-    public MultiSearchResponse perform(HashMap<String , List<HashMap<String,String>>> multiSearchParameters, HashMap<String, String> common_params) throws Exception {
+    public MultiSearchResponse perform(Map<String , List<Map<String,String>>> multiSearchParameters, Map<String, String> common_params) throws Exception {
         return this.apiCall.post(MultiSearch.RESOURCEPATH, multiSearchParameters, common_params, MultiSearchResponse.class);
     }
 }

--- a/src/main/java/org/typesense/api/Operations.java
+++ b/src/main/java/org/typesense/api/Operations.java
@@ -1,6 +1,6 @@
 package org.typesense.api;
 
-import java.util.HashMap;
+import java.util.Map;
 
 public class Operations {
 
@@ -11,11 +11,11 @@ public class Operations {
         this.apiCall = apiCall;
     }
 
-    public HashMap<String, String> perform(String operationName, HashMap<String, String> queryParameters) throws Exception {
-        return this.apiCall.post(RESOUCEPATH + "/" + operationName, "{}", queryParameters, HashMap.class);
+    public Map<String, String> perform(String operationName, Map<String, String> queryParameters) throws Exception {
+        return this.apiCall.post(RESOUCEPATH + "/" + operationName, "{}", queryParameters, Map.class);
     }
 
-    public HashMap<String, String> perform(String operationName) throws Exception {
-        return this.apiCall.post(RESOUCEPATH + "/" + operationName, "{}", null, HashMap.class);
+    public Map<String, String> perform(String operationName) throws Exception {
+        return this.apiCall.post(RESOUCEPATH + "/" + operationName, "{}", null, Map.class);
     }
 }

--- a/src/test/java/org/typesense/api/DocumentsTest.java
+++ b/src/test/java/org/typesense/api/DocumentsTest.java
@@ -8,6 +8,8 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.Scanner;
 
 public class DocumentsTest extends TestCase {
@@ -106,7 +108,7 @@ public class DocumentsTest extends TestCase {
         HashMap<String, Object> document1 = new HashMap<>();
         HashMap<String, Object> document2 = new HashMap<>();
         ImportDocumentsParameters queryParameters = new ImportDocumentsParameters();
-        ArrayList<HashMap<String, Object>> documentList = new ArrayList<>();
+        List<Map<String, Object>> documentList = new ArrayList<>();
 
         document1.put("countryName","India");
         document1.put("capital","Delhi");

--- a/src/test/java/org/typesense/api/Helper.java
+++ b/src/test/java/org/typesense/api/Helper.java
@@ -1,6 +1,5 @@
 package org.typesense.api;
 
-import org.typesense.api.exceptions.TypesenseError;
 import org.typesense.model.*;
 import org.typesense.resources.Node;
 
@@ -13,7 +12,7 @@ public class Helper {
     private final Client client;
 
     Helper() {
-        ArrayList<Node> nodes = new ArrayList<>();
+        List<Node> nodes = new ArrayList<>();
         nodes.add(new Node("http","localhost","8108"));
 
         Configuration configuration = new Configuration(nodes, Duration.ofSeconds(3),"xyz");
@@ -22,7 +21,7 @@ public class Helper {
     }
 
     public void createTestCollection() throws Exception {
-        ArrayList<Field> fields = new ArrayList<>();
+        List<Field> fields = new ArrayList<>();
         fields.add(new Field().name(".*").type(FieldTypes.AUTO).optional(true));
 
         CollectionSchema collectionSchema = new CollectionSchema();

--- a/src/test/java/org/typesense/api/MultiSearchTest.java
+++ b/src/test/java/org/typesense/api/MultiSearchTest.java
@@ -1,14 +1,12 @@
 package org.typesense.api;
 
 import junit.framework.TestCase;
-import org.typesense.api.exceptions.TypesenseError;
 import org.typesense.model.CollectionSchema;
 import org.typesense.model.Field;
-import org.typesense.resources.Node;
 
-import java.time.Duration;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.Map;
 import java.util.List;
 
 public class MultiSearchTest extends TestCase {
@@ -31,7 +29,7 @@ public class MultiSearchTest extends TestCase {
         client.collections().create(collectionSchema);
 
         String[] authors = {"shakspeare","william"};
-        HashMap<String, Object> hmap = new HashMap<>();
+        Map<String, Object> hmap = new HashMap<>();
         hmap.put("title","Romeo and juliet");
         hmap.put("authors",authors);
         hmap.put("publication_year",1666);
@@ -47,8 +45,8 @@ public class MultiSearchTest extends TestCase {
     }
 
     public void testSearch() throws Exception {
-        HashMap<String,String > val1 = new HashMap<>();
-        HashMap<String,String > val2 = new HashMap<>();
+        Map<String,String > val1 = new HashMap<>();
+        Map<String,String > val2 = new HashMap<>();
 
         val1.put("collection","books");
         val1.put("q","romeo");
@@ -56,11 +54,11 @@ public class MultiSearchTest extends TestCase {
         val2.put("collection","brands");
         val2.put("q","juliet");
 
-        List<HashMap<String, String>> list = new ArrayList<>();
+        List<Map<String, String>> list = new ArrayList<>();
         list.add(val2);
         list.add(val1);
 
-        HashMap<String, List<HashMap<String ,String>>> map = new HashMap<>();
+        Map<String, List<Map<String ,String>>> map = new HashMap<>();
         map.put("searches",list);
 
         /*ObjectMapper objectMapper = new ObjectMapper();
@@ -70,7 +68,7 @@ public class MultiSearchTest extends TestCase {
         } catch (JsonProcessingException e) {
             e.printStackTrace();
         }*/
-        HashMap<String,String> common_params = new HashMap<>();
+        Map<String,String> common_params = new HashMap<>();
         common_params.put("query_by","title");
 
         System.out.println(this.client.multiSearch.perform(map, common_params));


### PR DESCRIPTION
## Change Summary
Update client classes to use base collection interfaces in method signatures.
This allows for more flexibility for end users than the concrete implementations `HashMap` and `ArrayList`.

Change is backwards compatible with prior usage of the client.

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
