### PR TITLE
Add preset to SearchParameters and MultiSearchParameters

### DIFF
--- a/src/main/java/org/typesense/model/MultiSearchParameters.java
+++ b/src/main/java/org/typesense/model/MultiSearchParameters.java
@@ -200,6 +200,12 @@ public class MultiSearchParameters   {
   **/
   private Boolean preSegmentedQuery = null;
   
+  @Schema(description = "Search using a bunch of search parameters by setting this parameter to the name of the existing Preset. ")
+ /**
+   * Search using a bunch of search parameters by setting this parameter to the name of the existing Preset.   
+  **/
+  private String preset = null;
+  
   @Schema(description = "If you have some overrides defined but want to disable all of them during query time, you can do that by setting this parameter to false ")
  /**
    * If you have some overrides defined but want to disable all of them during query time, you can do that by setting this parameter to false   
@@ -794,6 +800,24 @@ public class MultiSearchParameters   {
   }
 
  /**
+   * Search using a bunch of search parameters by setting this parameter to the name of the existing Preset. 
+   * @return preset
+  **/
+  @JsonProperty("preset")
+  public String getPreset() {
+    return preset;
+  }
+
+  public void setPreset(String preset) {
+    this.preset = preset;
+  }
+
+  public MultiSearchParameters preset(String preset) {
+    this.preset = preset;
+    return this;
+  }
+
+ /**
    * If you have some overrides defined but want to disable all of them during query time, you can do that by setting this parameter to false 
    * @return enableOverrides
   **/
@@ -991,6 +1015,7 @@ public class MultiSearchParameters   {
     sb.append("    hiddenHits: ").append(toIndentedString(hiddenHits)).append("\n");
     sb.append("    highlightFields: ").append(toIndentedString(highlightFields)).append("\n");
     sb.append("    preSegmentedQuery: ").append(toIndentedString(preSegmentedQuery)).append("\n");
+    sb.append("    preset: ").append(toIndentedString(preset)).append("\n");
     sb.append("    enableOverrides: ").append(toIndentedString(enableOverrides)).append("\n");
     sb.append("    prioritizeExactMatch: ").append(toIndentedString(prioritizeExactMatch)).append("\n");
     sb.append("    exhaustiveSearch: ").append(toIndentedString(exhaustiveSearch)).append("\n");

--- a/src/main/java/org/typesense/model/SearchParameters.java
+++ b/src/main/java/org/typesense/model/SearchParameters.java
@@ -207,6 +207,12 @@ public class SearchParameters   {
   **/
   private Boolean preSegmentedQuery = null;
   
+  @Schema(description = "Search using a bunch of search parameters by setting this parameter to the name of the existing Preset. ")
+ /**
+   * Search using a bunch of search parameters by setting this parameter to the name of the existing Preset.   
+  **/
+  private String preset = null;
+  
   @Schema(description = "If you have some overrides defined but want to disable all of them during query time, you can do that by setting this parameter to false ")
  /**
    * If you have some overrides defined but want to disable all of them during query time, you can do that by setting this parameter to false   
@@ -849,6 +855,24 @@ public class SearchParameters   {
   }
 
  /**
+   * Search using a bunch of search parameters by setting this parameter to the name of the existing Preset. 
+   * @return preset
+  **/
+  @JsonProperty("preset")
+  public String getPreset() {
+    return preset;
+  }
+
+  public void setPreset(String preset) {
+    this.preset = preset;
+  }
+
+  public SearchParameters preset(String preset) {
+    this.preset = preset;
+    return this;
+  }
+
+ /**
    * If you have some overrides defined but want to disable all of them during query time, you can do that by setting this parameter to false 
    * @return enableOverrides
   **/
@@ -1084,6 +1108,7 @@ public class SearchParameters   {
     sb.append("    highlightFields: ").append(toIndentedString(highlightFields)).append("\n");
     sb.append("    splitJoinTokens: ").append(toIndentedString(splitJoinTokens)).append("\n");
     sb.append("    preSegmentedQuery: ").append(toIndentedString(preSegmentedQuery)).append("\n");
+    sb.append("    preset: ").append(toIndentedString(preset)).append("\n");
     sb.append("    enableOverrides: ").append(toIndentedString(enableOverrides)).append("\n");
     sb.append("    prioritizeExactMatch: ").append(toIndentedString(prioritizeExactMatch)).append("\n");
     sb.append("    maxCandidates: ").append(toIndentedString(maxCandidates)).append("\n");

--- a/src/test/java/org/typesense/api/DocumentsTest.java
+++ b/src/test/java/org/typesense/api/DocumentsTest.java
@@ -61,6 +61,22 @@ class DocumentsTest {
     }
 
     @Test
+    void testUnknownPresetsDoNotFailSearches() throws Exception {
+        helper.createTestDocument();
+        Map<String, Object> resp = client.collections("books").documents("1").retrieve();
+        assertEquals("Romeo and juliet", resp.get("title"));
+
+        SearchParameters params = new SearchParameters()
+                .q("Romeo")
+                .queryBy("title")
+                .preset("non_existent_preset");
+
+        SearchResult searchResult = client.collections("books").documents().search(params);
+        assertEquals(1, searchResult.getFound().intValue());
+        assertEquals(1, searchResult.getHits().size());
+    }
+
+    @Test
     void testUpsertDocument() throws Exception {
         helper.createTestDocument();
 


### PR DESCRIPTION
## Change Summary
Addresses https://github.com/typesense/typesense-java/issues/41 by adding `.preset(...)` to `SearchParameters` and `MultiSearchParameters`. This is a follow up to https://github.com/typesense/typesense-api-spec/pull/37.

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
