### PR TITLE
updating okhttp3 dependency to address cves

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,6 +7,6 @@ hamcrestVersion=1.3
 jacksonCoreVersion=2.14.1
 javaxXmlBindVersion=2.3.1
 junitJupiterVersion=5.9.3
-okhttp3Version=4.9.1
+okhttp3Version=4.10.0
 slf4jVersion=2.0.5
 swaggerCoreV3Version=2.0.0


### PR DESCRIPTION
This pr addresses these CVEs in dependencies:

* CVE-2023-3635
* CVE-2022-24329
* CVE-2020-29582

The changelog for okhttp3 makes this look like purely bug and security fixes.

## Change Summary
<!--- Described your changes here -->
This will get the security scanner at our company off our backs by updating insecure dependencies.

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
