### PR TITLE
+feature: Create a new collection from JSON file

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,15 @@ collectionSchema.name("Countries").fields(fields).defaultSortingField("gdp");
 client.collections().create(collectionSchema);
 ```
 
+### Create a new collection from JSON file
+```java
+String schemaJson = new String(
+    Files.readAllBytes(Paths.get("schema.json")),
+    StandardCharsets.UTF_8
+);
+client.collections().create(schemaJson);
+```
+
 ### Index a document
 ```java
 Map<String, Object> hmap = new HashMap<>();

--- a/src/main/java/org/typesense/api/Collections.java
+++ b/src/main/java/org/typesense/api/Collections.java
@@ -16,6 +16,10 @@ public class Collections {
         return this.apiCall.post(RESOURCE_PATH, c, null, CollectionResponse.class);
     }
 
+    public CollectionResponse create(String schemaJson) throws Exception {
+        return this.apiCall.post(RESOURCE_PATH, schemaJson, null, CollectionResponse.class);
+    }
+
     public CollectionResponse[] retrieve() throws Exception {
         return this.apiCall.get(RESOURCE_PATH, null, CollectionResponse[].class);
     }


### PR DESCRIPTION
## Change Summary
Keep Typesense schema definition in a *.json file provides many advantages: it's easy to edit and is self-documenting.
This feature allows to use JSON schema definition (from the *.json file) in Java API.


## PR Checklist
- [x ] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
