### PR TITLE
Fix Node health checks referencing a null pointer

### DIFF
--- a/src/main/java/org/typesense/api/ApiCall.java
+++ b/src/main/java/org/typesense/api/ApiCall.java
@@ -61,7 +61,7 @@ public class ApiCall {
     // Loops in a round-robin fashion to check for a healthy node and returns it
     Node getNode() {
         if (configuration.nearestNode != null) {
-            if (isDueForHealthCheck((configuration.nearestNode)) || configuration.nearestNode.isHealthy) {
+            if (configuration.nearestNode.isHealthy || isDueForHealthCheck((configuration.nearestNode)) ) {
                 return configuration.nearestNode;
             }
         }

--- a/src/main/java/org/typesense/resources/Node.java
+++ b/src/main/java/org/typesense/resources/Node.java
@@ -25,6 +25,7 @@ public class Node {
         this.host = host;
         this.port = port;
         this.isHealthy = true;
+        this.lastAccessTimestamp = LocalDateTime.now();
 
         if (protocol == null) {
             throw new RuntimeException("Protocol cannot be null");

--- a/src/test/java/org/typesense/api/APICallTest.java
+++ b/src/test/java/org/typesense/api/APICallTest.java
@@ -20,7 +20,7 @@ class APICallTest {
         List<Node> nodes = new ArrayList<>();
         nodes.add(new Node("http","localhost","8108"));
         nodes.add(new Node("http","localhost","7108"));
-        nodes.add(new Node("http","localhost","2108"));
+        nodes.add(new Node("http","localhost","6108"));
         apiCall = new ApiCall(new Configuration(nodes, Duration.ofSeconds(3),"xyz"));
     }
 


### PR DESCRIPTION
# What is this?

This pull request aims to improve the reliability and efficiency of the Typesense Java client by enhancing node health checks and API call logic. It's addressing potential issues (#61) with node selection and improving testing coverage to ensure more robust behavior in cluster configuration scenarios.

# Changes

## Added Features:

1. **New Methods in `APICallTest.java`**:
   - `setUpNoNearestNode()`: Sets up test scenarios without a nearest node.
   - `setUpNearestNode()`: Sets up test scenarios with a nearest node.

2. **New Test Cases in `APICallTest.java`**:
   - `testUnhealthyNearestNode()`: Verifies correct node selection when the nearest node is unhealthy.
   - `testHealthyNearestNode()`: Ensures the nearest node is selected when healthy.
   - `testUnhealthyNearestNodeDueForHealthCheck()`: Checks if an unhealthy nearest node is selected for a health check after a certain time.

## Code Changes:

1. **In `Node.java`**:
   - Added initialization of `lastAccessTimestamp` in the constructor to support health check scheduling.

2. **In `ApiCall.java`**:
   - Adjusted the condition in `getNode()` method to prioritize checking if the nearest node is healthy before checking if it's due for a health check, to avoid running more checks, as the first OR statement that resolves to true will make the condition exit.

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
