### PR TITLE
fix: add java.net.ConnectException to the list of errors that force h…

### DIFF
--- a/src/main/java/org/typesense/api/ApiCall.java
+++ b/src/main/java/org/typesense/api/ApiCall.java
@@ -184,7 +184,8 @@ public class ApiCall {
                                       (e instanceof ServiceUnavailable) ||
                                       (e instanceof SocketTimeoutException) ||
                                       (e instanceof java.net.UnknownHostException) ||
-                                      (e instanceof SSLException);
+                                      (e instanceof SSLException) ||
+                                      (e instanceof java.net.ConnectException);
 
                 if(!handleError) {
                     // we just throw and move on


### PR DESCRIPTION
…andling the error in the client so if during the usage of a node, the client would mark it as unhealthy if it just is not reachable.
Fix for https://github.com/typesense/typesense-java/issues/64

## Change Summary
Added java.net.ConnectException to the list of errors that force handling the erorr in the client

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
