### PR TITLE
feat(stopwords): add stopwords support

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,34 @@ AnalyticsEventCreateSchema analyticsEvent = new AnalyticsEventCreateSchema()
 client.analytics().events().create(analyticsEvent);
 ```
 
+### Upsert a stopwords set
+```java
+List<String> stopwords = new ArrayList<>();
+stopwords.add("the");
+stopwords.add("of");
+stopwords.add("and");
+
+StopwordsSetUpsertSchema stopwordsSet = new StopwordsSetUpsertSchema();
+stopwordsSet.stopwords(stopwords);
+
+client.stopwords().upsert("common-words", stopwordsSet);
+```
+
+### Retrieve a stopwords set
+```java
+StopwordsSetRetrieveSchema set = client.stopwords("common-words").retrieve();
+```
+
+### Retrieve all stopwords sets
+```java
+StopwordsSetsRetrieveAllSchema sets = client.stopwords().retrieve();
+```
+
+### Delete a stopwords set
+```java
+client.stopwords("common-words").delete();
+```
+
 ### Create an API key
 ```java
 ApiKeySchema apiKeySchema = new ApiKeySchema();

--- a/src/main/java/org/typesense/api/Client.java
+++ b/src/main/java/org/typesense/api/Client.java
@@ -21,6 +21,9 @@ public class Client {
 
     private Analytics analytics;
 
+    private Stopwords stopwords;
+    private Map<String, StopwordsSet> individualStopwordsSets;
+
     public Health health;
     public Operations operations;
     public Metrics metrics;
@@ -42,6 +45,8 @@ public class Client {
         this.debug = new Debug(this.apiCall);
         this.multiSearch = new MultiSearch(this.apiCall);
         this.analytics = new Analytics(this.apiCall);
+        this.stopwords = new Stopwords(this.apiCall);
+        this.individualStopwordsSets = new HashMap<>();
     }
 
     public Collection collections(String name){
@@ -93,5 +98,20 @@ public class Client {
 
     public Analytics analytics(){
         return this.analytics;
+    }
+
+    public Stopwords stopwords() {
+        return this.stopwords;
+    }
+
+    public StopwordsSet stopwords(String stopwordsSetId) {
+        StopwordsSet retVal;
+
+        if (!this.individualStopwordsSets.containsKey(stopwordsSetId)) {
+            this.individualStopwordsSets.put(stopwordsSetId, new StopwordsSet(stopwordsSetId, this.apiCall));
+        }
+
+        retVal = this.individualStopwordsSets.get(stopwordsSetId);
+        return retVal;
     }
 }

--- a/src/main/java/org/typesense/api/Stopwords.java
+++ b/src/main/java/org/typesense/api/Stopwords.java
@@ -1,0 +1,29 @@
+package org.typesense.api;
+
+import org.typesense.api.utils.URLEncoding;
+import org.typesense.model.StopwordsSetSchema;
+import org.typesense.model.StopwordsSetUpsertSchema;
+import org.typesense.model.StopwordsSetsRetrieveAllSchema;
+
+public class Stopwords {
+    public final static String RESOURCEPATH = "/stopwords";
+
+    private final ApiCall apiCall;
+
+    public Stopwords(ApiCall apiCall) {
+        this.apiCall = apiCall;
+    }
+
+    public StopwordsSetSchema upsert(String stopwordSetId, StopwordsSetUpsertSchema stopwordSet) throws Exception {
+        return this.apiCall.put(getEndpoint(stopwordSetId), stopwordSet, null, StopwordsSetSchema.class);
+    }
+
+    public StopwordsSetsRetrieveAllSchema retrieve() throws Exception {
+        return this.apiCall.get(Stopwords.RESOURCEPATH, null, StopwordsSetsRetrieveAllSchema.class);
+    }
+
+    private String getEndpoint(String stopwordSetId) {
+        return RESOURCEPATH + "/" + URLEncoding.encodeURIComponent(stopwordSetId);
+    }
+
+}

--- a/src/main/java/org/typesense/api/StopwordsSet.java
+++ b/src/main/java/org/typesense/api/StopwordsSet.java
@@ -1,0 +1,28 @@
+package org.typesense.api;
+
+import org.typesense.api.utils.URLEncoding;
+import org.typesense.model.StopwordsSetRetrieveSchema;
+import org.typesense.model.StopwordsSetSchema;
+
+public class StopwordsSet {
+    private final ApiCall apiCall;
+    private final String stopwordsSetId;
+
+    public StopwordsSet(String stopwordsSetId, ApiCall apiCall) {
+        this.stopwordsSetId = stopwordsSetId;
+        this.apiCall = apiCall;
+    }
+
+    public StopwordsSetRetrieveSchema retrieve() throws Exception {
+        return this.apiCall.get(this.getEndpoint(), null, StopwordsSetRetrieveSchema.class);
+    }
+
+    public StopwordsSetSchema delete() throws Exception {
+        return this.apiCall.delete(this.getEndpoint(), null, StopwordsSetSchema.class);
+    }
+
+    private String getEndpoint() {
+        return Stopwords.RESOURCEPATH + "/" + URLEncoding.encodeURIComponent(this.stopwordsSetId);
+    }
+
+}

--- a/src/test/java/org/typesense/api/Helper.java
+++ b/src/test/java/org/typesense/api/Helper.java
@@ -25,6 +25,9 @@ import org.typesense.model.SearchOverrideInclude;
 import org.typesense.model.SearchOverrideRule;
 import org.typesense.model.SearchOverrideSchema;
 import org.typesense.model.SearchSynonymSchema;
+import org.typesense.model.StopwordsSetSchema;
+import org.typesense.model.StopwordsSetUpsertSchema;
+import org.typesense.model.StopwordsSetsRetrieveAllSchema;
 import org.typesense.resources.Node;
 
 public class Helper {
@@ -125,6 +128,18 @@ public class Helper {
         client.analytics().rules().upsert("analytics-rule", analyticsRuleSchema);
     }
 
+    public void createTestStopwordsSet() throws Exception {
+        List<String> stopwords = new ArrayList<>();
+        stopwords.add("the");
+        stopwords.add("of");
+        stopwords.add("and");
+
+        StopwordsSetUpsertSchema stopwordsSetSchema = new StopwordsSetUpsertSchema();
+        stopwordsSetSchema.stopwords(stopwords);
+
+        client.stopwords().upsert("common-words", stopwordsSetSchema);
+    }
+
     public void teardown() throws Exception {
         CollectionResponse[] collectionResponses = client.collections().retrieve();
         for (CollectionResponse c : collectionResponses) {
@@ -144,6 +159,11 @@ public class Helper {
         ApiKeysResponse apiKeysResponse = client.keys().retrieve();
         for (ApiKey k : apiKeysResponse.getKeys()) {
             client.keys(k.getId()).delete();
+        }
+
+        StopwordsSetsRetrieveAllSchema stopwords = client.stopwords().retrieve();
+        for (StopwordsSetSchema s : stopwords.getStopwords()) {
+            client.stopwords(s.getId()).delete();
         }
     }
 }

--- a/src/test/java/org/typesense/api/StopwordsTest.java
+++ b/src/test/java/org/typesense/api/StopwordsTest.java
@@ -1,0 +1,91 @@
+package org.typesense.api;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.AfterEach;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.typesense.model.StopwordsSetRetrieveSchema;
+import org.typesense.model.StopwordsSetSchema;
+import org.typesense.model.StopwordsSetUpsertSchema;
+import org.typesense.model.StopwordsSetsRetrieveAllSchema;
+
+public class StopwordsTest {
+
+    private Client client;
+    private Helper helper;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        helper = new Helper();
+        client = helper.getClient();
+        helper.teardown();
+        helper.createTestCollection();
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        helper.teardown();
+    }
+
+    @Test
+    void testUpsert() throws Exception {
+        List<String> stopwords = new ArrayList<>();
+        stopwords.add("the");
+        stopwords.add("of");
+        stopwords.add("and");
+
+        StopwordsSetUpsertSchema stopwordsSetSchema = new StopwordsSetUpsertSchema();
+        stopwordsSetSchema.stopwords(stopwords);
+
+        client.stopwords().upsert("common-words", stopwordsSetSchema);
+    }
+
+    @Test
+    void testRetrieve() throws Exception {
+        helper.createTestStopwordsSet();
+
+        StopwordsSetRetrieveSchema result = this.client.stopwords("common-words").retrieve();
+
+        assertNotNull(result);
+
+        StopwordsSetSchema set = result.getStopwords();
+
+        assertEquals("common-words", set.getId());
+        assertEquals(3, set.getStopwords().size());
+        assertEquals("and", set.getStopwords().get(0));
+        assertEquals("the", set.getStopwords().get(1));
+        assertEquals("of", set.getStopwords().get(2));
+    }
+
+    @Test
+    void testRetrieveAll() throws Exception {
+        helper.createTestStopwordsSet();
+
+        StopwordsSetsRetrieveAllSchema result = this.client.stopwords().retrieve();
+
+        assertNotNull(result);
+        assertEquals(1, result.getStopwords().size());
+
+        StopwordsSetSchema set = result.getStopwords().get(0);
+
+        assertEquals("common-words", set.getId());
+        assertEquals(3, set.getStopwords().size());
+        assertEquals("and", set.getStopwords().get(0));
+        assertEquals("the", set.getStopwords().get(1));
+        assertEquals("of", set.getStopwords().get(2));
+    }
+
+    @Test
+    void testDelete() throws Exception {
+        helper.createTestStopwordsSet();
+
+        StopwordsSetSchema result = this.client.stopwords("common-words").delete();
+
+        assertNotNull(result);
+        assertEquals("common-words", result.getId());
+    }
+}


### PR DESCRIPTION
## Change Summary
## Rationale
This enhancement adds support for managing stopwords in the Typesense Java client.

By implementing stopwords management, users can:
- Create and maintain custom stopwords lists
- Apply different stopwords sets for different use cases
- Easily manage stopwords through a clean API interface

## Changes

### Added Features:
1. **New Class `Stopwords.java`**:
   - `upsert()`: Creates or updates a stopwords set with specified ID
   - `retrieve()`: Gets all available stopwords sets
   - Base endpoint management for stopwords operations

2. **New Class `StopwordsSet.java`**:
   - `retrieve()`: Gets details of a specific stopwords set
   - `delete()`: Removes a stopwords set
   - Individual stopwords set management functionality

3. **Client Integration in `Client.java`**:
   - `stopwords()`: New method providing access to global stopwords operations
   - `stopwords(String stopwordsSetId)`: Method for accessing individual stopwords set operations
   - Added proper instance management for stopwords functionality

### Code Changes:
1. **In `Client.java`**:
   - Added stopwords management instance variables
   - Implemented stopwords access methods
   - Added initialization in constructor

### Documentation Updates:
1. **In `README.md`**:
   - Added code examples for all stopwords operations:
     - Upserting a stopwords set
     - Retrieving individual and all stopwords sets
     - Deleting stopwords sets
   - Clear usage examples with realistic data

### Test Coverage:
1. **New Test Class `StopwordsTest.java`**:
   - Comprehensive test coverage for all stopwords operations
   - Tests for upsert, retrieve, retrieve all, and delete operations
   - Proper setup and teardown handling

2. **Updates to `Helper.java`**:
   - Added stopwords support in test utilities
   - Implemented cleanup for stopwords in teardown

## Context
This implementation aligns with Typesense's stopwords management API endpoints and provides a Java-friendly interface for managing stopwords. The changes follow existing patterns in the client library for consistency and ease of use. All operations are properly tested and documented to ensure reliability and maintainability.


## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
