### PR TITLE
fix(keys): fix delete schema response

### DIFF
--- a/src/main/java/org/typesense/api/Key.java
+++ b/src/main/java/org/typesense/api/Key.java
@@ -1,5 +1,6 @@
 package org.typesense.api;
 
+import org.typesense.interfaces.ApiKeyDeleteResponse;
 import org.typesense.model.ApiKey;
 
 public class Key {
@@ -16,8 +17,8 @@ public class Key {
         return this.apiCall.get(this.getEndpoint(), null, ApiKey.class);
     }
 
-    public ApiKey delete() throws Exception {
-        return this.apiCall.delete(this.getEndpoint(), null, ApiKey.class);
+    public ApiKeyDeleteResponse delete() throws Exception {
+        return this.apiCall.delete(this.getEndpoint(), null, ApiKeyDeleteResponse.class);
     }
 
     private String getEndpoint(){

--- a/src/main/java/org/typesense/interfaces/ApiKeyDeleteResponse.java
+++ b/src/main/java/org/typesense/interfaces/ApiKeyDeleteResponse.java
@@ -1,0 +1,57 @@
+package org.typesense.interfaces;
+
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public class ApiKeyDeleteResponse {
+    @JsonProperty("id")
+    private Long id = null;
+
+    public ApiKeyDeleteResponse id(Long id) {
+        this.id = id;
+        return this;
+    }
+
+    /**
+     * The unique identifier of the deleted key
+     * @return id
+    **/
+    @Schema(required = true, description = "The unique identifier of the deleted key")
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ApiKeyDeleteResponse that = (ApiKeyDeleteResponse) o;
+        return Objects.equals(this.id, that.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class ApiKeyDeleteResponse {\n");
+        sb.append("    id: ").append(toIndentedString(id)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    private String toIndentedString(Object o) {
+        if (o == null) return "null";
+        return o.toString().replace("\n", "\n    ");
+    }
+}


### PR DESCRIPTION
## Change Summary
Add a new interface for response schemas after deletion, as the API only returns the id of the API key instead of the whole object.
```shell
❯ curl -k "http://localhost:8108/keys/15" \
      -X DELETE \
      -H "Content-Type: application/json" \
      -H "X-TYPESENSE-API-KEY: ${TYPESENSE-API-KEY}" \
{"id":15} // Nothing other than the id of the key
```
This is part of a larger problem regarding the OpenAPI spec, as according to it, the 200 response schema of a API Key DELETE request is defined as:
```yml
  /keys/{keyId}:
    delete:
      tags:
        - keys
      summary: Delete an API key given its ID.
      operationId: deleteKey
      parameters:
        - name: keyId
          in: path
          description: The ID of the key to delete
          required: true
          schema:
            type: integer
            format: int64
      responses:
        200:
          description: The key referenced by the ID
          content:
            application/json:
              schema:
                $ref: "#/components/schemas/ApiKey"
```
Where the `ApiKey` schema is defined as:
```yml
    ApiKeySchema:
      type: object
      required:
        - actions
        - collections
        - description
      properties:
        value:
          type: string
        description:
          type: string
        actions:
          type: array
          items:
            type: string
        collections:
          type: array
          items:
            type: string
        expires_at:
          type: integer
          format: int64
    ApiKey:
      allOf:
        - $ref: "#/components/schemas/ApiKeySchema"
        - type: object
          properties:
            id:
              type: integer
              format: int64
              readOnly: true
            value_prefix:
              type: string
              readOnly: true
```
## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
