### PR TITLE
fix(synonym): fix delete response of synonym

### DIFF
--- a/src/main/java/org/typesense/api/Synonym.java
+++ b/src/main/java/org/typesense/api/Synonym.java
@@ -2,6 +2,7 @@ package org.typesense.api;
 
 import org.typesense.api.utils.URLEncoding;
 import org.typesense.model.SearchSynonym;
+import org.typesense.model.SearchSynonymDeleteResponse;
 
 public class Synonym {
 
@@ -19,8 +20,8 @@ public class Synonym {
         return this.apiCall.get(this.getEndpoint(), null, SearchSynonym.class);
     }
 
-    public SearchSynonym delete() throws Exception {
-        return this.apiCall.delete(this.getEndpoint(), null, SearchSynonym.class);
+    public SearchSynonymDeleteResponse delete() throws Exception {
+        return this.apiCall.delete(this.getEndpoint(), null, SearchSynonymDeleteResponse.class);
     }
 
     public String getEndpoint() {


### PR DESCRIPTION
## Change Summary
As discussed in https://github.com/typesense/typesense-api-spec/pull/80, the actual API does not return the whole Synonym object, but rather just its `id`. This now uses the latest updates from the API spec to properly handle the deletion response object.

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
