### PR TITLE
fix(overrides): fix override delete response type

### DIFF
--- a/src/main/java/org/typesense/api/Override.java
+++ b/src/main/java/org/typesense/api/Override.java
@@ -2,6 +2,7 @@ package org.typesense.api;
 
 import org.typesense.api.utils.URLEncoding;
 import org.typesense.model.SearchOverride;
+import org.typesense.model.SearchOverrideDeleteResponse;
 
 public class Override {
 
@@ -19,8 +20,8 @@ public class Override {
         return this.apiCall.get(this.getEndpoint(), null, SearchOverride.class);
     }
 
-    public SearchOverride delete() throws Exception {
-        return this.apiCall.delete(this.getEndpoint(), null, SearchOverride.class);
+    public SearchOverrideDeleteResponse delete() throws Exception {
+        return this.apiCall.delete(this.getEndpoint(), null, SearchOverrideDeleteResponse.class);
     }
 
     public String getEndpoint() {


### PR DESCRIPTION
## Change Summary
As discussed in https://github.com/typesense/typesense-api-spec/pull/79, the actual API does not return the whole Override object, but rather just its `id`. This now uses the latest updates from the API spec to properly handle the deletion response object.

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
