### PR TITLE
Use Testcontainers Typesense module

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,18 +14,6 @@ jobs:
     strategy:
       matrix:
         java: ['8', '11', '17']
-    services:
-      typesense:
-        image: typesense/typesense:27.0
-        ports:
-          - 8108:8108/tcp
-        volumes:
-          - /tmp/typesense-server-data:/data
-        env:
-          TYPESENSE_DATA_DIR: '/data'
-          TYPESENSE_API_KEY: 'xyz'
-          TYPESENSE_ENABLE_CORS: true
-          TYPESENSE_URL: 'http://localhost:8108'
     name: Java ${{ matrix.Java }}
     steps:
       - name: Checkout sources

--- a/build.gradle
+++ b/build.gradle
@@ -110,6 +110,8 @@ dependencies {
     testImplementation "org.mockito:mockito-core:${mokitoVerion}"
     testImplementation "org.mockito:mockito-junit-jupiter:${mokitoVerion}"
     testImplementation "org.hamcrest:hamcrest-all:${hamcrestVersion}"
+    testImplementation "org.testcontainers:junit-jupiter:${testcontainersVersion}"
+    testImplementation "org.testcontainers:typesense:${testcontainersVersion}"
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:${junitJupiterVersion}"
 
     integrationTestImplementation "org.junit.jupiter:junit-jupiter-api:${junitJupiterVersion}"

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,3 +11,4 @@ mokitoVerion=4.11.0
 okhttp3Version=4.10.0
 slf4jVersion=2.0.5
 swaggerCoreV3Version=2.0.0
+testcontainersVersion=1.20.4

--- a/src/test/java/org/typesense/api/AliasesTest.java
+++ b/src/test/java/org/typesense/api/AliasesTest.java
@@ -5,19 +5,25 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.typesense.TypesenseContainer;
 import org.typesense.model.CollectionAlias;
 import org.typesense.model.CollectionAliasSchema;
 import org.typesense.model.CollectionAliasesResponse;
 
+@Testcontainers
 class AliasesTest {
+    
+    @Container
+    static TypesenseContainer typesense = new TypesenseContainer(Helper.IMAGE);
 
     private Client client;
     private Helper helper;
 
     @BeforeEach
     void setUp() throws Exception {
-        helper = new Helper();
-        helper.teardown();
+        helper = new Helper(typesense);
         client = helper.getClient();
         helper.createTestAlias();
     }
@@ -41,7 +47,7 @@ class AliasesTest {
         collectionAliasSchema.collectionName("books_june11");
 
         CollectionAlias res = client.aliases().upsert("books1 ~!@#$%^&*()_++-=/'", collectionAliasSchema);
-        assertEquals(res.getName(), "books1 ~!@#$%^&*()_++-=/'");
+        assertEquals("books1 ~!@#$%^&*()_++-=/'", res.getName());
         System.out.println(res);
     }
 

--- a/src/test/java/org/typesense/api/AnalyticsEventsTest.java
+++ b/src/test/java/org/typesense/api/AnalyticsEventsTest.java
@@ -7,19 +7,25 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.typesense.TypesenseContainer;
 import org.typesense.model.AnalyticsEventCreateResponse;
 import org.typesense.model.AnalyticsEventCreateSchema;
 
+@Testcontainers
 public class AnalyticsEventsTest {
+
+    @Container
+    static TypesenseContainer typesense = new TypesenseContainer(Helper.IMAGE);
 
     private Client client;
     private Helper helper;
 
     @BeforeEach
     void setUp() throws Exception {
-        helper = new Helper();
+        helper = new Helper(typesense);
         client = helper.getClient();
-        helper.teardown();
         helper.createTestCollection();
         helper.createTestQueryCollection();
         helper.createTestAnalyticsRule();

--- a/src/test/java/org/typesense/api/AnalyticsRulesTest.java
+++ b/src/test/java/org/typesense/api/AnalyticsRulesTest.java
@@ -7,6 +7,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.typesense.TypesenseContainer;
 import org.typesense.model.AnalyticsRuleDeleteResponse;
 import org.typesense.model.AnalyticsRuleParameters;
 import org.typesense.model.AnalyticsRuleParametersDestination;
@@ -15,16 +18,19 @@ import org.typesense.model.AnalyticsRuleSchema;
 import org.typesense.model.AnalyticsRuleUpsertSchema;
 import org.typesense.model.AnalyticsRulesRetrieveSchema;
 
+@Testcontainers
 public class AnalyticsRulesTest {
+
+    @Container
+    static TypesenseContainer typesense = new TypesenseContainer(Helper.IMAGE);
 
     private Client client;
     private Helper helper;
 
     @BeforeEach
     void setUp() throws Exception {
-        helper = new Helper();
+        helper = new Helper(typesense);
         client = helper.getClient();
-        helper.teardown();
         helper.createTestCollection();
         helper.createTestQueryCollection();
     }

--- a/src/test/java/org/typesense/api/CollectionsTest.java
+++ b/src/test/java/org/typesense/api/CollectionsTest.java
@@ -3,20 +3,25 @@ package org.typesense.api;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.typesense.TypesenseContainer;
 import org.typesense.model.*;
 
 import java.util.ArrayList;
 
-
+@Testcontainers
 class CollectionsTest {
+
+    @Container
+    static TypesenseContainer typesense = new TypesenseContainer(Helper.IMAGE);
 
     Client client;
     private Helper helper;
 
     @BeforeEach
     void setUp() throws Exception {
-        helper = new Helper();
-        helper.teardown();
+        helper = new Helper(typesense);
         this.client = helper.getClient();
     }
 

--- a/src/test/java/org/typesense/api/DocumentsTest.java
+++ b/src/test/java/org/typesense/api/DocumentsTest.java
@@ -10,8 +10,13 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.typesense.TypesenseContainer;
 import org.typesense.api.exceptions.ObjectNotFound;
 import org.typesense.model.CollectionSchema;
 import org.typesense.model.DeleteDocumentsParameters;
@@ -24,17 +29,25 @@ import org.typesense.model.SearchParameters;
 import org.typesense.model.SearchResult;
 import org.typesense.model.UpdateDocumentsParameters;
 
+@Testcontainers
 class DocumentsTest {
+
+        @Container
+        static TypesenseContainer typesense = new TypesenseContainer(Helper.IMAGE);
 
         Client client;
         private Helper helper;
 
         @BeforeEach
         void setUp() throws Exception {
-                helper = new Helper();
+                helper = new Helper(typesense);
                 this.client = helper.getClient();
-                helper.teardown();
                 helper.createTestCollection();
+        }
+
+        @AfterEach
+        void tearDown() throws Exception {
+                helper.teardown();
         }
 
         @Test

--- a/src/test/java/org/typesense/api/HealthAndOperationsTest.java
+++ b/src/test/java/org/typesense/api/HealthAndOperationsTest.java
@@ -3,18 +3,24 @@ package org.typesense.api;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.typesense.TypesenseContainer;
 
 import java.util.HashMap;
 
+@Testcontainers
 class HealthAndOperationsTest {
 
+    @Container
+    static TypesenseContainer typesense = new TypesenseContainer(Helper.IMAGE);    
+    
     private Client client;
     private Helper helper;
 
     @BeforeEach
     void setUp() throws Exception {
-        helper = new Helper();
-        helper.teardown();
+        helper = new Helper(typesense);
         client = helper.getClient();
     }
 

--- a/src/test/java/org/typesense/api/Helper.java
+++ b/src/test/java/org/typesense/api/Helper.java
@@ -6,6 +6,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 
+import org.testcontainers.typesense.TypesenseContainer;
 import org.typesense.model.AnalyticsRuleParameters;
 import org.typesense.model.AnalyticsRuleParametersDestination;
 import org.typesense.model.AnalyticsRuleParametersSource;
@@ -31,13 +32,16 @@ import org.typesense.model.StopwordsSetsRetrieveAllSchema;
 import org.typesense.resources.Node;
 
 public class Helper {
+    
+    final static String IMAGE = "typesense/typesense:27.0";
+    
     private final Client client;
 
-    Helper() {
+    Helper(TypesenseContainer container) {
         List<Node> nodes = new ArrayList<>();
-        nodes.add(new Node("http", "localhost", "8108"));
+        nodes.add(new Node("http", container.getHost(), container.getHttpPort()));
 
-        Configuration configuration = new Configuration(nodes, Duration.ofSeconds(3), "xyz");
+        Configuration configuration = new Configuration(nodes, Duration.ofSeconds(3), container.getApiKey());
 
         this.client = new Client(configuration);
     }

--- a/src/test/java/org/typesense/api/KeysTest.java
+++ b/src/test/java/org/typesense/api/KeysTest.java
@@ -3,6 +3,9 @@ package org.typesense.api;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.typesense.TypesenseContainer;
 import org.typesense.model.ApiKey;
 import org.typesense.model.ApiKeySchema;
 
@@ -10,7 +13,11 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 
+@Testcontainers
 class KeysTest {
+
+    @Container
+    static TypesenseContainer typesense = new TypesenseContainer(Helper.IMAGE);
 
     private Client client;
     private Helper helper;
@@ -19,8 +26,7 @@ class KeysTest {
 
     @BeforeEach
     void setUp() throws Exception {
-        helper = new Helper();
-        helper.teardown();
+        helper = new Helper(typesense);
         client = helper.getClient();
         ApiKey key = helper.createTestKey();
         testKey = key.getValue();

--- a/src/test/java/org/typesense/api/MultiSearchTest.java
+++ b/src/test/java/org/typesense/api/MultiSearchTest.java
@@ -3,6 +3,9 @@ package org.typesense.api;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.typesense.TypesenseContainer;
 import org.typesense.model.CollectionSchema;
 import org.typesense.model.Field;
 import org.typesense.model.MultiSearchCollectionParameters;
@@ -16,17 +19,19 @@ import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+@Testcontainers
 class MultiSearchTest {
+
+    @Container
+    static TypesenseContainer typesense = new TypesenseContainer(Helper.IMAGE);
 
     private Client client;
     private Helper helper;
 
     @BeforeEach
     void setUp() throws Exception {
-        helper = new Helper();
+        helper = new Helper(typesense);
         client = helper.getClient();
-
-        helper.teardown();
 
         // create a collection with 2 fields: title and vec to store embeddings
         List<Field> fields = new ArrayList<>();

--- a/src/test/java/org/typesense/api/OverridesTest.java
+++ b/src/test/java/org/typesense/api/OverridesTest.java
@@ -3,6 +3,9 @@ package org.typesense.api;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.typesense.TypesenseContainer;
 import org.typesense.model.SearchOverrideExclude;
 import org.typesense.model.SearchOverrideInclude;
 import org.typesense.model.SearchOverrideRule;
@@ -11,15 +14,18 @@ import org.typesense.model.SearchOverrideSchema;
 import java.util.ArrayList;
 import java.util.List;
 
+@Testcontainers
 class OverridesTest {
+
+    @Container
+    static TypesenseContainer typesense = new TypesenseContainer(Helper.IMAGE);
 
     private Client client;
     private Helper helper;
 
     @BeforeEach
     void setUp() throws Exception {
-        helper = new Helper();
-        helper.teardown();
+        helper = new Helper(typesense);
         client = helper.getClient();
         helper.createTestCollection();
         helper.createTestOverrirde();

--- a/src/test/java/org/typesense/api/StopwordsTest.java
+++ b/src/test/java/org/typesense/api/StopwordsTest.java
@@ -8,21 +8,27 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.typesense.TypesenseContainer;
 import org.typesense.model.StopwordsSetRetrieveSchema;
 import org.typesense.model.StopwordsSetSchema;
 import org.typesense.model.StopwordsSetUpsertSchema;
 import org.typesense.model.StopwordsSetsRetrieveAllSchema;
 
+@Testcontainers
 public class StopwordsTest {
+
+    @Container
+    static TypesenseContainer typesense = new TypesenseContainer(Helper.IMAGE);
 
     private Client client;
     private Helper helper;
 
     @BeforeEach
     void setUp() throws Exception {
-        helper = new Helper();
+        helper = new Helper(typesense);
         client = helper.getClient();
-        helper.teardown();
         helper.createTestCollection();
     }
 

--- a/src/test/java/org/typesense/api/SynonymsTest.java
+++ b/src/test/java/org/typesense/api/SynonymsTest.java
@@ -3,18 +3,24 @@ package org.typesense.api;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.typesense.TypesenseContainer;
 import org.typesense.model.SearchSynonymSchema;
 
+@Testcontainers
 class SynonymsTest {
+
+    @Container
+    static TypesenseContainer typesense = new TypesenseContainer(Helper.IMAGE);
 
     private Client client;
     private Helper helper;
 
     @BeforeEach
     void setUp() throws Exception {
-        helper = new Helper();
+        helper = new Helper(typesense);
         client = helper.getClient();
-        helper.teardown();
         helper.createTestCollection();
         helper.createTestSynonym();
     }


### PR DESCRIPTION
Current tests depend on an running instance of Typesense. Adding
Testcontainers, test will start and stop the Typesense instance
as part of the test lifecycle. Enabling local and CI/CD executions
to have the same environment.
