### PR TITLE
v28: Add Stemming API

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
         java: ['8', '11', '17']
     services:
       typesense:
-        image: typesense/typesense:27.0
+        image: typesense/typesense:28.0.rc36
         ports:
           - 8108:8108/tcp
         volumes:

--- a/src/main/java/org/typesense/api/Client.java
+++ b/src/main/java/org/typesense/api/Client.java
@@ -21,6 +21,8 @@ public class Client {
 
     private Analytics analytics;
 
+    private Stemming stemming;
+
     private Stopwords stopwords;
     private Map<String, StopwordsSet> individualStopwordsSets;
 
@@ -45,6 +47,7 @@ public class Client {
         this.debug = new Debug(this.apiCall);
         this.multiSearch = new MultiSearch(this.apiCall);
         this.analytics = new Analytics(this.apiCall);
+        this.stemming = new Stemming(this.apiCall);
         this.stopwords = new Stopwords(this.apiCall);
         this.individualStopwordsSets = new HashMap<>();
     }
@@ -98,6 +101,10 @@ public class Client {
 
     public Analytics analytics(){
         return this.analytics;
+    }
+
+    public Stemming stemming(){
+        return this.stemming;
     }
 
     public Stopwords stopwords() {

--- a/src/main/java/org/typesense/api/Stemming.java
+++ b/src/main/java/org/typesense/api/Stemming.java
@@ -1,0 +1,32 @@
+package org.typesense.api;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class Stemming {
+    private final ApiCall apiCall;
+    private final StemmingDictionaries dictionaries;
+    private final Map<String, StemmingDictionary> individualDictionaries;
+
+
+    public Stemming(ApiCall apiCall) {
+        this.apiCall = apiCall;
+        this.dictionaries = new StemmingDictionaries(this.apiCall);
+        this.individualDictionaries = new HashMap<>();
+    }
+
+    public StemmingDictionaries dictionaries() {
+        return this.dictionaries;
+    }
+
+    public StemmingDictionary dictionaries(String dictionaryId) {
+        StemmingDictionary retVal;
+
+        if (!this.individualDictionaries.containsKey(dictionaryId)) {
+            this.individualDictionaries.put(dictionaryId, new StemmingDictionary(dictionaryId, apiCall));
+        }
+
+        retVal = this.individualDictionaries.get(dictionaryId);
+        return retVal;
+    }
+}

--- a/src/main/java/org/typesense/api/StemmingDictionaries.java
+++ b/src/main/java/org/typesense/api/StemmingDictionaries.java
@@ -1,0 +1,59 @@
+package org.typesense.api;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import org.typesense.model.StemmingDictionaryWords;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+public class StemmingDictionaries {
+    private final ApiCall apiCall;
+    public final static String RESOURCE_PATH = "/stemming/dictionaries";
+
+    public StemmingDictionaries(ApiCall apiCall) {
+        this.apiCall = apiCall;
+    }
+
+    public String upsert(String dictionaryId, String wordRootCombinations) throws Exception {
+        Map<String, String> params = Collections.singletonMap("id", dictionaryId);
+
+        return this.apiCall.post(this.getEndPoint("import"), wordRootCombinations, params, String.class);
+    }
+
+    public List<StemmingDictionaryWords> upsert(String dictionaryId, List<StemmingDictionaryWords> wordRootCombinations)
+            throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+        List<String> jsonLines = new ArrayList<>();
+        List<StemmingDictionaryWords> objectList = new ArrayList<>();
+
+        for (StemmingDictionaryWords word : wordRootCombinations) {
+            jsonLines.add(mapper.writeValueAsString(word));
+        }
+
+        String reqBody = String.join("\n", jsonLines);
+
+        Map<String, String> params = Collections.singletonMap("id", dictionaryId);
+
+        String resInJsonLineFormat = this.apiCall.post(this.getEndPoint("import"), reqBody, params, String.class);
+
+        for (String line : resInJsonLineFormat.split("\n")) {
+            objectList.add(mapper.readValue(line, StemmingDictionaryWords.class));
+        }
+
+        return objectList;
+    }
+
+    public StemmingDictionariesRetrieveSchema retrieve() throws Exception {
+        StemmingDictionariesRetrieveSchema response = this.apiCall.get(RESOURCE_PATH, null,
+                StemmingDictionariesRetrieveSchema.class);
+        return response != null ? response : new StemmingDictionariesRetrieveSchema();
+    }
+
+    public String getEndPoint(String target) {
+        return RESOURCE_PATH + "/" + target;
+    }
+
+}

--- a/src/main/java/org/typesense/api/StemmingDictionariesRetrieveSchema.java
+++ b/src/main/java/org/typesense/api/StemmingDictionariesRetrieveSchema.java
@@ -1,0 +1,15 @@
+package org.typesense.api;
+
+import java.util.List;
+
+public class StemmingDictionariesRetrieveSchema {
+    private List<String> dictionaries;
+
+    public List<String> getDictionaries() {
+        return dictionaries;
+    }
+
+    public void setDictionaries(List<String> dictionaries) {
+        this.dictionaries = dictionaries;
+    }
+}

--- a/src/main/java/org/typesense/api/StemmingDictionary.java
+++ b/src/main/java/org/typesense/api/StemmingDictionary.java
@@ -1,0 +1,23 @@
+package org.typesense.api;
+
+import org.typesense.api.utils.URLEncoding;
+
+public class StemmingDictionary {
+    private final ApiCall apiCall;
+    private final String dictionaryId;
+
+    public StemmingDictionary(String dictionaryId, ApiCall apiCall) {
+        this.apiCall = apiCall;
+        this.dictionaryId = dictionaryId;
+    }
+
+
+    public org.typesense.model.StemmingDictionary retrieve() throws Exception {
+        return this.apiCall.get(this.getEndpoint(), null, org.typesense.model.StemmingDictionary.class);
+    }
+
+    private String getEndpoint() {
+        return StemmingDictionaries.RESOURCE_PATH + "/" + URLEncoding.encodeURIComponent(this.dictionaryId);
+    }
+    
+}

--- a/src/test/java/org/typesense/api/Helper.java
+++ b/src/test/java/org/typesense/api/Helper.java
@@ -25,6 +25,7 @@ import org.typesense.model.SearchOverrideInclude;
 import org.typesense.model.SearchOverrideRule;
 import org.typesense.model.SearchOverrideSchema;
 import org.typesense.model.SearchSynonymSchema;
+import org.typesense.model.StemmingDictionaryWords;
 import org.typesense.model.StopwordsSetSchema;
 import org.typesense.model.StopwordsSetUpsertSchema;
 import org.typesense.model.StopwordsSetsRetrieveAllSchema;
@@ -138,6 +139,16 @@ public class Helper {
         stopwordsSetSchema.stopwords(stopwords);
 
         client.stopwords().upsert("common-words", stopwordsSetSchema);
+    }
+
+
+    public void createStemmingDictionary() throws Exception{
+        List<StemmingDictionaryWords> stemmingDictionaryWords = new ArrayList<>();
+
+        stemmingDictionaryWords.add(new StemmingDictionaryWords().word("ran").root("run"));
+        stemmingDictionaryWords.add(new StemmingDictionaryWords().word("running").root("run"));
+
+        client.stemming().dictionaries().upsert("irregular-plurals", stemmingDictionaryWords);
     }
 
     public void teardown() throws Exception {

--- a/src/test/java/org/typesense/api/StemmingTest.java
+++ b/src/test/java/org/typesense/api/StemmingTest.java
@@ -1,0 +1,54 @@
+package org.typesense.api;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.typesense.model.StemmingDictionary;
+import org.typesense.model.StemmingDictionaryWords;
+
+public class StemmingTest {
+    private Client client;
+    private Helper helper;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        helper = new Helper();
+        helper.teardown();
+        client = helper.getClient();
+        helper.createStemmingDictionary();
+    }
+
+    @Test
+    void testUpsert() throws Exception {
+        List<StemmingDictionaryWords> stemmingDictionaryWords = new ArrayList<>();
+
+        stemmingDictionaryWords.add(new StemmingDictionaryWords().word("ran").root("run"));
+        stemmingDictionaryWords.add(new StemmingDictionaryWords().word("running").root("run"));
+
+        List<StemmingDictionaryWords> res = client.stemming().dictionaries().upsert("irregular-plurals",
+                stemmingDictionaryWords);
+
+        assertEquals(2, res.size());
+        assertEquals("ran", res.get(0).getWord());
+        assertEquals("run", res.get(0).getRoot());
+        assertEquals("running", res.get(1).getWord());
+        assertEquals("run", res.get(1).getRoot());
+    }
+
+    @Test
+    void testRetrieveOne() throws Exception {
+        StemmingDictionary res = client.stemming().dictionaries("irregular-plurals").retrieve();
+        assertEquals("irregular-plurals", res.getId());
+        assertEquals(2, res.getWords().size());
+    }
+
+    @Test
+    void testRetrieveAll() throws Exception {
+         StemmingDictionariesRetrieveSchema res = client.stemming().dictionaries().retrieve();
+        assertEquals(1, res.getDictionaries().size());
+        assertEquals("irregular-plurals", res.getDictionaries().get(0));
+    }
+}


### PR DESCRIPTION

## Change Summary
<!--- Described your changes here -->
This pull request introduces a new stemming feature to the Typesense API client. The changes include adding new classes for handling stemming dictionaries, updating the `Client` class to include stemming functionality, and adding tests to ensure the new functionality works correctly.

### New Stemming Feature:

* [`src/main/java/org/typesense/api/Client.java`](diffhunk://#diff-92b8a667e26d8d254557ad68525f119fd236a31c127a061c72e55ca9ce83d428R24-R25): Added a `Stemming` member and corresponding methods to the `Client` class to support stemming operations. [[1]](diffhunk://#diff-92b8a667e26d8d254557ad68525f119fd236a31c127a061c72e55ca9ce83d428R24-R25) [[2]](diffhunk://#diff-92b8a667e26d8d254557ad68525f119fd236a31c127a061c72e55ca9ce83d428R50) [[3]](diffhunk://#diff-92b8a667e26d8d254557ad68525f119fd236a31c127a061c72e55ca9ce83d428R106-R109)

* [`src/main/java/org/typesense/api/Stemming.java`](diffhunk://#diff-00da71de1cd4c935b02a7dd9486d94adb06c31c0eb0da7413a8df7dcd6a85dc1R1-R32): Introduced a new `Stemming` class that manages stemming dictionaries and individual stemming dictionary instances.

* [`src/main/java/org/typesense/api/StemmingDictionaries.java`](diffhunk://#diff-87eb3d7064a69635125dc4a560af1b53645bd4de15536880d20a3fd4c83933ecR1-R59): Added a `StemmingDictionaries` class to handle operations such as upserting and retrieving stemming dictionaries.

* [`src/main/java/org/typesense/api/StemmingDictionariesRetrieveSchema.java`](diffhunk://#diff-b7ce76095ff6c9356dd800e355cf60e875f8d44fe426e1aac6fe5c5f34d0b9c6R1-R15): Created a schema class for retrieving stemming dictionaries.

* [`src/main/java/org/typesense/api/StemmingDictionary.java`](diffhunk://#diff-0e11cacdd481fd982f0f79c0dbf27b46e4fcb77dc733fe4eee632b30dd0e93e7R1-R23): Added a `StemmingDictionary` class to handle individual stemming dictionary operations.

### Testing:

* [`src/test/java/org/typesense/api/Helper.java`](diffhunk://#diff-fb3150c39b4633fc396a7138b63a2c622624337223b5f437dcbdef5362f69fb3R28): Updated the `Helper` class to include methods for creating and tearing down stemming dictionaries for testing purposes. [[1]](diffhunk://#diff-fb3150c39b4633fc396a7138b63a2c622624337223b5f437dcbdef5362f69fb3R28) [[2]](diffhunk://#diff-fb3150c39b4633fc396a7138b63a2c622624337223b5f437dcbdef5362f69fb3R144-R153)

* [`src/test/java/org/typesense/api/StemmingTest.java`](diffhunk://#diff-6a5029ec9b1acf8aa069cd3040e223dad4d0d06578e3a49eca2457c8bce7f228R1-R54): Added a new test class `StemmingTest` to verify the functionality of stemming dictionary operations, including upserting and retrieving dictionaries.- Add `Stemming` class to manage dictionary operations
- Add `StemmingDictionaries` to handle bulk dictionary operations
- Add `StemmingDictionary` to manage individual dictionaries
- Add `StemmingDictionariesRetrieveSchema` for API responses
- Add tests for dictionary creation and retrieval


## PR Checklist
[x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
