### PR TITLE
Added a constructor with custom OkHttpClient

### DIFF
--- a/src/main/java/org/typesense/api/Client.java
+++ b/src/main/java/org/typesense/api/Client.java
@@ -1,6 +1,8 @@
 package org.typesense.api;
 
 
+import okhttp3.OkHttpClient;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -31,6 +33,26 @@ public class Client {
     public Metrics metrics;
     public Debug debug;
     public MultiSearch multiSearch;
+
+    public Client(Configuration configuration, OkHttpClient okHttpClient){
+        this.configuration = configuration;
+        this.apiCall = new ApiCall(configuration, okHttpClient);
+        collections = new Collections(apiCall);
+        this.individualCollections = new HashMap<>();
+        this.aliases = new Aliases(this.apiCall);
+        this.individualAliases = new HashMap<>();
+        this.keys = new Keys(this.apiCall);
+        this.individualKeys = new HashMap<>();
+        this.health = new Health(this.apiCall);
+        this.operations = new Operations(this.apiCall);
+        this.metrics = new Metrics(this.apiCall);
+        this.debug = new Debug(this.apiCall);
+        this.multiSearch = new MultiSearch(this.apiCall);
+        this.analytics = new Analytics(this.apiCall);
+        this.stemming = new Stemming(this.apiCall);
+        this.stopwords = new Stopwords(this.apiCall);
+        this.individualStopwordsSets = new HashMap<>();
+    }
 
     public Client(Configuration configuration){
         this.configuration = configuration;


### PR DESCRIPTION
## Change Summary
To customize certain aspects of the HTTP calls being made, we need to access and control the HTTP client being used. This PR adds another constructor for the client to accept, in addition to the configuration, an `OkHttpClient`, which is simply passed to the `APIClient` that already accepts such a parameter.

## PR Checklist
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
