### PR TITLE
docs: add docgen tool and generate javadocs for API client classes

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1780749050,
+        "narHash": "sha256-3av0pIjlOWQ6rDbNOmpUSvbNnJkGORQKKjb4LtCZsIY=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "a799d3e3886da994fa307f817a6bc705ae538eeb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,40 @@
+{
+  description = "Typesense Java client dev shell";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs {
+          inherit system;
+          config.permittedInsecurePackages = [ "gradle-7.6.6" ];
+        };
+      in {
+        devShells.default = pkgs.mkShell {
+          buildInputs = with pkgs; [
+            jdk17
+            gradle_7
+            jdt-language-server
+          ];
+
+          JDK8_HOME = "${pkgs.jdk8}";
+
+          shellHook = ''
+            export JAVA_HOME=${pkgs.jdk17}
+            echo "Java (jdtls/build runtime):"
+            java -version
+            echo ""
+            echo "Project JDK 8 available at: $JDK8_HOME"
+            echo ""
+            echo "Gradle:"
+            gradle --version | grep '^Gradle'
+            echo ""
+            echo "jdtls: $(command -v jdtls)"
+          '';
+        };
+      });
+}

--- a/generator/build.gradle
+++ b/generator/build.gradle
@@ -1,0 +1,29 @@
+plugins {
+    id 'java'
+    id 'application'
+}
+
+repositories {
+    mavenCentral()
+}
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
+}
+
+dependencies {
+    implementation 'com.github.javaparser:javaparser-core:3.25.10'
+    implementation 'org.yaml:snakeyaml:2.2'
+}
+
+application {
+    mainClass = 'org.typesense.docgen.DocGen'
+}
+
+tasks.named('run') {
+    // Pass spec + wrapper dir via -PspecPath / -PwrapperDir or rely on defaults.
+    def specPath = project.findProperty('specPath') ?: "${rootDir}/../../api-spec/openapi.yml"
+    def wrapperDir = project.findProperty('wrapperDir') ?: "${rootDir}/../src/main/java/org/typesense/api"
+    args = [specPath, wrapperDir]
+}

--- a/generator/settings.gradle
+++ b/generator/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'typesense-java-docgen'

--- a/generator/src/main/java/org/typesense/docgen/DocGen.java
+++ b/generator/src/main/java/org/typesense/docgen/DocGen.java
@@ -1,0 +1,515 @@
+package org.typesense.docgen;
+
+import com.github.javaparser.StaticJavaParser;
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.NodeList;
+import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
+import com.github.javaparser.ast.body.ConstructorDeclaration;
+import com.github.javaparser.ast.body.FieldDeclaration;
+import com.github.javaparser.ast.body.MethodDeclaration;
+import com.github.javaparser.ast.body.Parameter;
+import com.github.javaparser.ast.body.VariableDeclarator;
+import com.github.javaparser.ast.expr.AssignExpr;
+import com.github.javaparser.ast.expr.BinaryExpr;
+import com.github.javaparser.ast.expr.ConditionalExpr;
+import com.github.javaparser.ast.expr.EnclosedExpr;
+import com.github.javaparser.ast.expr.Expression;
+import com.github.javaparser.ast.expr.FieldAccessExpr;
+import com.github.javaparser.ast.expr.MethodCallExpr;
+import com.github.javaparser.ast.expr.NameExpr;
+import com.github.javaparser.ast.expr.StringLiteralExpr;
+import com.github.javaparser.ast.expr.ThisExpr;
+import com.github.javaparser.ast.stmt.ReturnStmt;
+import com.github.javaparser.printer.lexicalpreservation.LexicalPreservingPrinter;
+import org.yaml.snakeyaml.Yaml;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public final class DocGen {
+
+    private static final String DOCS_BASE_URL = "https://typesense.org/docs/latest/api/";
+
+    private static final Map<String, String> TAG_TO_DOCS;
+    static {
+        TAG_TO_DOCS = new HashMap<String, String>();
+        TAG_TO_DOCS.put("collections", "collections.html");
+        TAG_TO_DOCS.put("documents", "documents.html");
+        TAG_TO_DOCS.put("keys", "api-keys.html");
+        TAG_TO_DOCS.put("aliases", "collection-alias.html");
+        TAG_TO_DOCS.put("synonyms", "synonyms.html");
+        TAG_TO_DOCS.put("curation_sets", "curation.html");
+        TAG_TO_DOCS.put("stopwords", "stopwords.html");
+        TAG_TO_DOCS.put("presets", "search.html#presets");
+        TAG_TO_DOCS.put("analytics", "analytics-query-suggestions.html");
+        TAG_TO_DOCS.put("conversations", "conversational-search-rag.html");
+        TAG_TO_DOCS.put("stemming", "stemming.html");
+        TAG_TO_DOCS.put("nl_search_models", "natural-language-search.html");
+        TAG_TO_DOCS.put("debug", "cluster-operations.html#debug");
+        TAG_TO_DOCS.put("health", "cluster-operations.html#health");
+        TAG_TO_DOCS.put("operations", "cluster-operations.html");
+    }
+
+    private static final Set<String> VERBS = new HashSet<String>(
+            Arrays.asList("get", "post", "put", "patch", "delete"));
+
+    public static void main(String[] args) throws Exception {
+        if (args.length < 2) {
+            System.err.println("usage: DocGen <openapi.yml> <wrapper-dir>");
+            System.exit(2);
+        }
+        Path specPath = Paths.get(args[0]);
+        Path wrapperDir = Paths.get(args[1]);
+
+        Map<String, OpInfo> opIndex = loadOpIndex(specPath);
+        System.out.println("docgen: loaded " + opIndex.size() + " operations from spec");
+
+        List<Path> files;
+        Stream<Path> s = Files.list(wrapperDir);
+        try {
+            files = s.filter(p -> p.toString().endsWith(".java"))
+                    .sorted()
+                    .collect(Collectors.toList());
+        } finally {
+            s.close();
+        }
+
+        Registry registry = new Registry();
+        Map<Path, CompilationUnit> parsed = new LinkedHashMap<Path, CompilationUnit>();
+        for (Path f : files) {
+            CompilationUnit cu = StaticJavaParser.parse(f);
+            LexicalPreservingPrinter.setup(cu);
+            parsed.put(f, cu);
+            indexUnit(cu, registry);
+        }
+
+        int touched = 0;
+        for (Map.Entry<Path, CompilationUnit> e : parsed.entrySet()) {
+            Path f = e.getKey();
+            CompilationUnit cu = e.getValue();
+            boolean changed = annotateUnit(cu, registry, opIndex);
+            if (changed) {
+                String out = LexicalPreservingPrinter.print(cu);
+                Files.write(f, out.getBytes());
+                touched++;
+                System.out.println("docgen: updated " + f.getFileName());
+            }
+        }
+        System.out.println("docgen: " + touched + " wrapper file(s) updated");
+    }
+
+    static final class OpInfo {
+        final String operationId;
+        final String method;
+        final String path;
+        final String summary;
+        final String description;
+        final String tag;
+
+        OpInfo(String operationId, String method, String path, String summary, String description, String tag) {
+            this.operationId = operationId;
+            this.method = method;
+            this.path = path;
+            this.summary = summary == null ? "" : summary.trim();
+            this.description = description == null ? "" : description.trim();
+            this.tag = tag == null ? "" : tag;
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Map<String, OpInfo> loadOpIndex(Path specPath) throws IOException {
+        Yaml yaml = new Yaml();
+        Object root;
+        InputStream in = Files.newInputStream(specPath);
+        try {
+            root = yaml.load(in);
+        } finally {
+            in.close();
+        }
+        if (!(root instanceof Map)) {
+            throw new IOException("spec root is not a map");
+        }
+        Map<String, Object> spec = (Map<String, Object>) root;
+        Object pathsObj = spec.get("paths");
+        if (!(pathsObj instanceof Map)) {
+            throw new IOException("spec missing paths");
+        }
+        Map<String, OpInfo> ops = new LinkedHashMap<String, OpInfo>();
+        for (Map.Entry<String, Object> e : ((Map<String, Object>) pathsObj).entrySet()) {
+            String path = e.getKey();
+            if (!(e.getValue() instanceof Map)) continue;
+            Map<String, Object> item = (Map<String, Object>) e.getValue();
+            for (Map.Entry<String, Object> me : item.entrySet()) {
+                String method = me.getKey().toLowerCase(Locale.ROOT);
+                if (!VERBS.contains(method)) continue;
+                if (!(me.getValue() instanceof Map)) continue;
+                Map<String, Object> op = (Map<String, Object>) me.getValue();
+                String opId = stringOrEmpty(op.get("operationId"));
+                String summary = stringOrEmpty(op.get("summary"));
+                String description = stringOrEmpty(op.get("description"));
+                String tag = "";
+                Object tagsObj = op.get("tags");
+                if (tagsObj instanceof List && !((List<?>) tagsObj).isEmpty()) {
+                    Object t = ((List<?>) tagsObj).get(0);
+                    if (t != null) tag = t.toString();
+                }
+                String key = method.toUpperCase(Locale.ROOT) + " " + normalizePath(path);
+                ops.put(key, new OpInfo(opId, method.toUpperCase(Locale.ROOT), path, summary, description, tag));
+            }
+        }
+        return ops;
+    }
+
+    private static String stringOrEmpty(Object o) {
+        return o == null ? "" : o.toString();
+    }
+
+    static final class Registry {
+        final Map<String, String> constants = new HashMap<String, String>();
+        final Map<String, MethodDeclaration> helpers = new HashMap<String, MethodDeclaration>();
+        final Map<String, Expression> instanceFields = new HashMap<String, Expression>();
+    }
+
+    private static void indexUnit(CompilationUnit cu, Registry reg) {
+        for (ClassOrInterfaceDeclaration cls : cu.findAll(ClassOrInterfaceDeclaration.class)) {
+            String name = cls.getNameAsString();
+            for (FieldDeclaration fd : cls.getFields()) {
+                for (VariableDeclarator vd : fd.getVariables()) {
+                    if (!"String".equals(vd.getTypeAsString())) continue;
+                    Optional<Expression> init = vd.getInitializer();
+                    if (!init.isPresent()) continue;
+                    Expression e = init.get();
+                    if (e instanceof StringLiteralExpr) {
+                        reg.constants.put(name + "." + vd.getNameAsString(),
+                                ((StringLiteralExpr) e).asString());
+                    }
+                }
+            }
+            for (MethodDeclaration m : cls.getMethods()) {
+                if (!"String".equals(m.getTypeAsString())) continue;
+                reg.helpers.put(name + "." + m.getNameAsString(), m);
+            }
+            for (ConstructorDeclaration c : cls.getConstructors()) {
+                List<AssignExpr> assigns = c.getBody().findAll(AssignExpr.class);
+                for (AssignExpr ae : assigns) {
+                    Expression target = ae.getTarget();
+                    if (target instanceof FieldAccessExpr) {
+                        FieldAccessExpr fae = (FieldAccessExpr) target;
+                        if (fae.getScope() instanceof ThisExpr) {
+                            reg.instanceFields.put(name + "." + fae.getNameAsString(), ae.getValue());
+                        }
+                    } else if (target instanceof NameExpr) {
+                        NameExpr ne = (NameExpr) target;
+                        reg.instanceFields.put(name + "." + ne.getNameAsString(), ae.getValue());
+                    }
+                }
+            }
+        }
+    }
+
+    private static boolean annotateUnit(CompilationUnit cu, Registry reg, Map<String, OpInfo> ops) {
+        boolean changed = false;
+        for (ClassOrInterfaceDeclaration cls : cu.findAll(ClassOrInterfaceDeclaration.class)) {
+            String className = cls.getNameAsString();
+            for (MethodDeclaration m : cls.getMethods()) {
+                if (!m.getBody().isPresent()) continue;
+                ApiCallSite site = findUniqueApiCall(m);
+                if (site == null) continue;
+                String resolved = resolvePath(site.pathArg, className, m, reg);
+                if (resolved == null) {
+                    System.out.println("docgen: cannot resolve path for " + className + "." + m.getNameAsString());
+                    continue;
+                }
+                String key = site.verb + " " + normalizePath(resolved);
+                OpInfo op = ops.get(key);
+                if (op == null) {
+                    System.out.println("docgen: no spec match for " + className + "." + m.getNameAsString()
+                            + " -> " + key);
+                    continue;
+                }
+                if (writeJavadoc(m, op)) {
+                    changed = true;
+                }
+            }
+        }
+        return changed;
+    }
+
+    static final class ApiCallSite {
+        final String verb;
+        final Expression pathArg;
+
+        ApiCallSite(String verb, Expression pathArg) {
+            this.verb = verb;
+            this.pathArg = pathArg;
+        }
+    }
+
+    private static ApiCallSite findUniqueApiCall(MethodDeclaration m) {
+        List<MethodCallExpr> all = m.getBody().get().findAll(MethodCallExpr.class);
+        List<MethodCallExpr> calls = new ArrayList<MethodCallExpr>();
+        for (MethodCallExpr c : all) {
+            if (isApiCall(c)) calls.add(c);
+        }
+        if (calls.size() != 1) return null;
+        MethodCallExpr call = calls.get(0);
+        String verb = call.getNameAsString().toUpperCase(Locale.ROOT);
+        if (call.getArguments().isEmpty()) return null;
+        return new ApiCallSite(verb, call.getArgument(0));
+    }
+
+    private static boolean isApiCall(MethodCallExpr call) {
+        if (!VERBS.contains(call.getNameAsString())) return false;
+        Optional<Expression> scope = call.getScope();
+        if (!scope.isPresent()) return false;
+        Expression s = scope.get();
+        if (s instanceof NameExpr) {
+            return "apiCall".equals(((NameExpr) s).getNameAsString());
+        }
+        if (s instanceof FieldAccessExpr) {
+            return "apiCall".equals(((FieldAccessExpr) s).getNameAsString());
+        }
+        return false;
+    }
+
+
+    private static String resolvePath(Expression expr, String className, MethodDeclaration owner, Registry reg) {
+        return resolve(expr, className, new HashMap<String, String>(), reg, 0, owner);
+    }
+
+    private static String resolve(Expression expr, String className, Map<String, String> scope, Registry reg,
+                                   int depth, MethodDeclaration owner) {
+        if (depth > 8) return null;
+        if (expr instanceof EnclosedExpr) {
+            return resolve(((EnclosedExpr) expr).getInner(), className, scope, reg, depth + 1, owner);
+        }
+        if (expr instanceof StringLiteralExpr) {
+            return ((StringLiteralExpr) expr).asString();
+        }
+        if (expr instanceof BinaryExpr) {
+            BinaryExpr be = (BinaryExpr) expr;
+            if (be.getOperator() == BinaryExpr.Operator.PLUS) {
+                String l = resolve(be.getLeft(), className, scope, reg, depth + 1, owner);
+                String r = resolve(be.getRight(), className, scope, reg, depth + 1, owner);
+                if (l == null || r == null) return null;
+                return l + r;
+            }
+            return null;
+        }
+        if (expr instanceof NameExpr) {
+            String n = ((NameExpr) expr).getNameAsString();
+            if (scope.containsKey(n)) return scope.get(n);
+            String fq = className + "." + n;
+            if (reg.constants.containsKey(fq)) return reg.constants.get(fq);
+            if (owner != null) {
+                for (Parameter p : owner.getParameters()) {
+                    if (p.getNameAsString().equals(n)) return "{" + n + "}";
+                }
+            }
+            if (reg.instanceFields.containsKey(fq)) {
+                return resolve(reg.instanceFields.get(fq), className, scope, reg, depth + 1, owner);
+            }
+            return null;
+        }
+        if (expr instanceof FieldAccessExpr) {
+            FieldAccessExpr fae = (FieldAccessExpr) expr;
+            if (fae.getScope() instanceof NameExpr) {
+                String fq = ((NameExpr) fae.getScope()).getNameAsString() + "." + fae.getNameAsString();
+                if (reg.constants.containsKey(fq)) return reg.constants.get(fq);
+            }
+            if (fae.getScope() instanceof ThisExpr) {
+                String fq = className + "." + fae.getNameAsString();
+                Expression init = reg.instanceFields.get(fq);
+                if (init == null) return "{" + fae.getNameAsString() + "}";
+                // Field assigned directly from a ctor param (e.g. this.id = id) -> placeholder.
+                if (init instanceof NameExpr) return "{" + fae.getNameAsString() + "}";
+                return resolve(init, className, scope, reg, depth + 1, owner);
+            }
+            return null;
+        }
+        if (expr instanceof ConditionalExpr) {
+            ConditionalExpr ce = (ConditionalExpr) expr;
+            String t = resolve(ce.getThenExpr(), className, scope, reg, depth + 1, owner);
+            String el = resolve(ce.getElseExpr(), className, scope, reg, depth + 1, owner);
+            if (!isEmpty(el) && isEmpty(t)) return el;
+            if (!isEmpty(t) && isEmpty(el)) return t;
+            if (t != null && t.indexOf('{') >= 0) return t;
+            if (el != null && el.indexOf('{') >= 0) return el;
+            return t != null ? t : el;
+        }
+        if (expr instanceof MethodCallExpr) {
+            MethodCallExpr mc = (MethodCallExpr) expr;
+            String name = mc.getNameAsString();
+            if ("encodeURIComponent".equals(name) && !mc.getArguments().isEmpty()) {
+                Expression arg = mc.getArgument(0);
+                String var = extractVarName(arg);
+                return "{" + (var != null ? var : "x") + "}";
+            }
+            String targetClass = className;
+            if (mc.getScope().isPresent()) {
+                Expression sc = mc.getScope().get();
+                if (sc instanceof NameExpr) {
+                    String n = ((NameExpr) sc).getNameAsString();
+                    if (!"this".equals(n)) targetClass = n;
+                }
+            }
+            String fq = targetClass + "." + name;
+            MethodDeclaration helper = reg.helpers.get(fq);
+            if (helper != null) {
+                return inlineHelper(helper, targetClass, mc.getArguments(), scope, reg, depth + 1, owner);
+            }
+            return null;
+        }
+        return null;
+    }
+
+    private static String inlineHelper(MethodDeclaration helper, String targetClass,
+                                        NodeList<Expression> args, Map<String, String> outerScope,
+                                        Registry reg, int depth, MethodDeclaration owner) {
+        if (!helper.getBody().isPresent()) return null;
+        Map<String, String> scope = new HashMap<String, String>();
+        for (int i = 0; i < helper.getParameters().size(); i++) {
+            String pname = helper.getParameter(i).getNameAsString();
+            String pval = null;
+            if (i < args.size()) {
+                pval = resolve(args.get(i), targetClass, outerScope, reg, depth + 1, owner);
+            }
+            if (pval == null) pval = "{" + pname + "}";
+            scope.put(pname, pval);
+        }
+        List<ReturnStmt> returns = helper.getBody().get().findAll(ReturnStmt.class);
+        if (returns.size() != 1) return null;
+        Optional<Expression> ret = returns.get(0).getExpression();
+        if (!ret.isPresent()) return null;
+        return resolve(ret.get(), targetClass, scope, reg, depth + 1, helper);
+    }
+
+    private static String extractVarName(Expression arg) {
+        if (arg instanceof NameExpr) return ((NameExpr) arg).getNameAsString();
+        if (arg instanceof FieldAccessExpr) return ((FieldAccessExpr) arg).getNameAsString();
+        if (arg instanceof EnclosedExpr) return extractVarName(((EnclosedExpr) arg).getInner());
+        return null;
+    }
+
+    private static boolean isEmpty(String s) {
+        return s == null || s.isEmpty();
+    }
+
+    private static String normalizePath(String path) {
+        if (path == null) return "";
+        while (path.length() > 1 && path.endsWith("/")) {
+            path = path.substring(0, path.length() - 1);
+        }
+        path = path.replaceAll("/+", "/");
+        path = path.replaceAll("\\{[^}]*\\}", "{}");
+        return path;
+    }
+
+    private static boolean writeJavadoc(MethodDeclaration m, OpInfo op) {
+        String content = renderJavadocContent(op);
+        if (m.getJavadocComment().isPresent()) {
+            String existing = m.getJavadocComment().get().getContent();
+            if (!isGeneratedJavadoc(existing)) {
+                return false;
+            }
+            if (normalizeJavadocContent(existing).equals(normalizeJavadocContent(content))) {
+                return false;
+            }
+        }
+        m.setJavadocComment(content);
+        return true;
+    }
+
+    private static boolean isGeneratedJavadoc(String content) {
+        return content != null
+                && content.contains("HTTP: ")
+                && content.contains("Typesense docs");
+    }
+
+    private static String normalizeJavadocContent(String content) {
+        if (content == null) return "";
+        return content.replace("\r\n", "\n").trim();
+    }
+
+    private static String renderJavadocContent(OpInfo op) {
+        List<String> lines = new ArrayList<String>();
+        String summary = sanitizeJavadocText(firstSentence(op.summary));
+        if (summary.isEmpty()) summary = sanitizeJavadocText(firstSentence(op.description));
+        if (!summary.isEmpty()) {
+            lines.add(ensureTrailingPeriod(upperFirst(summary)));
+        }
+        if (!op.description.isEmpty()
+                && !op.description.equalsIgnoreCase(op.summary)
+                && !firstSentence(op.description).equalsIgnoreCase(firstSentence(op.summary))) {
+            lines.add("");
+            lines.add("<p>");
+            for (String line : op.description.split("\n", -1)) {
+                lines.add(sanitizeJavadocText(line));
+            }
+        }
+        lines.add("");
+        lines.add("<p>");
+        lines.add("HTTP: " + op.method + " " + op.path);
+        String section = TAG_TO_DOCS.get(op.tag);
+        if (section != null) {
+            lines.add("");
+            lines.add("@see <a href=\"" + DOCS_BASE_URL + section + "\">Typesense docs</a>");
+        }
+        StringBuilder sb = new StringBuilder();
+        sb.append('\n');
+        for (String line : lines) {
+            if (line.isEmpty()) {
+                sb.append("     *\n");
+            } else {
+                sb.append("     * ").append(line).append('\n');
+            }
+        }
+        sb.append("     ");
+        return sb.toString();
+    }
+
+    private static String sanitizeJavadocText(String s) {
+        if (s == null || s.isEmpty()) return s;
+        return s.replaceAll("\\s*&amp;\\s*", " and ")
+                .replaceAll("\\s*&(?!#?[A-Za-z0-9]+;)\\s*", " and ")
+                .trim();
+    }
+
+    private static String firstSentence(String s) {
+        if (s == null) return "";
+        s = s.trim();
+        if (s.isEmpty()) return "";
+        int nl = s.indexOf('\n');
+        if (nl >= 0) s = s.substring(0, nl);
+        return s.trim();
+    }
+
+    private static String upperFirst(String s) {
+        if (s == null || s.isEmpty()) return s;
+        return Character.toUpperCase(s.charAt(0)) + s.substring(1);
+    }
+
+    private static String ensureTrailingPeriod(String s) {
+        if (s == null || s.isEmpty()) return s;
+        char c = s.charAt(s.length() - 1);
+        if (c == '.' || c == '?' || c == '!') return s;
+        return s + ".";
+    }
+
+    private DocGen() {}
+}

--- a/generator/src/main/java/org/typesense/docgen/DocGen.java
+++ b/generator/src/main/java/org/typesense/docgen/DocGen.java
@@ -21,6 +21,7 @@ import com.github.javaparser.ast.expr.NameExpr;
 import com.github.javaparser.ast.expr.StringLiteralExpr;
 import com.github.javaparser.ast.expr.ThisExpr;
 import com.github.javaparser.ast.stmt.ReturnStmt;
+import com.github.javaparser.ast.type.ReferenceType;
 import com.github.javaparser.printer.lexicalpreservation.LexicalPreservingPrinter;
 import org.yaml.snakeyaml.Yaml;
 
@@ -262,10 +263,12 @@ public final class DocGen {
     static final class ApiCallSite {
         final String verb;
         final Expression pathArg;
+        final MethodCallExpr call;
 
-        ApiCallSite(String verb, Expression pathArg) {
+        ApiCallSite(String verb, Expression pathArg, MethodCallExpr call) {
             this.verb = verb;
             this.pathArg = pathArg;
+            this.call = call;
         }
     }
 
@@ -279,7 +282,7 @@ public final class DocGen {
         MethodCallExpr call = calls.get(0);
         String verb = call.getNameAsString().toUpperCase(Locale.ROOT);
         if (call.getArguments().isEmpty()) return null;
-        return new ApiCallSite(verb, call.getArgument(0));
+        return new ApiCallSite(verb, call.getArgument(0), call);
     }
 
     private static boolean isApiCall(MethodCallExpr call) {
@@ -478,8 +481,8 @@ public final class DocGen {
         return renderJavadocBlock(lines, javadocIndent(c));
     }
 
-    private static boolean writeJavadoc(MethodDeclaration m, OpInfo op) {
-        String content = renderJavadocContent(op);
+    private static boolean writeJavadoc(MethodDeclaration m, OpInfo op, ApiCallSite site) {
+        String content = renderJavadocContent(m, op, site);
         if (m.getJavadocComment().isPresent()) {
             String existing = m.getJavadocComment().get().getContent();
             if (!isGeneratedJavadoc(existing)) {
@@ -516,7 +519,7 @@ public final class DocGen {
         return content.replace("\r\n", "\n").trim();
     }
 
-    private static String renderJavadocContent(OpInfo op) {
+    private static String renderJavadocContent(MethodDeclaration m, OpInfo op, ApiCallSite site) {
         List<String> lines = new ArrayList<String>();
         String summary = sanitizeJavadocText(firstSentence(op.summary));
         if (summary.isEmpty()) summary = sanitizeJavadocText(firstSentence(op.description));
@@ -535,22 +538,163 @@ public final class DocGen {
         lines.add("");
         lines.add("<p>");
         lines.add("HTTP: " + op.method + " " + op.path);
+
+        boolean hasParamTags = !m.getParameters().isEmpty();
+        boolean hasReturnTag = !"void".equals(m.getTypeAsString());
+        boolean hasThrowsTags = !m.getThrownExceptions().isEmpty();
+        if (hasParamTags || hasReturnTag || hasThrowsTags || TAG_TO_DOCS.containsKey(op.tag)) {
+            lines.add("");
+        }
+        addMethodParamTags(lines, m.getParameters(), site);
+        if (hasReturnTag) {
+            lines.add("@return " + describeReturn(m));
+        }
+        for (ReferenceType thrown : m.getThrownExceptions()) {
+            lines.add("@throws " + thrown.asString() + " if the request fails");
+        }
+
         String section = TAG_TO_DOCS.get(op.tag);
         if (section != null) {
             lines.add("");
             lines.add("@see <a href=\"" + DOCS_BASE_URL + section + "\">Typesense docs</a>");
         }
+        return renderJavadocBlock(lines, javadocIndent(m));
+    }
+
+    private static void addMethodParamTags(List<String> lines, NodeList<Parameter> parameters, ApiCallSite site) {
+        for (Parameter p : parameters) {
+            String name = p.getNameAsString();
+            lines.add("@param " + name + " " + describeMethodParam(p, site));
+        }
+    }
+
+    private static void addConstructorParamTags(List<String> lines, NodeList<Parameter> parameters) {
+        for (Parameter p : parameters) {
+            String name = p.getNameAsString();
+            lines.add("@param " + name + " " + describeConstructorParam(p));
+        }
+    }
+
+    private static String describeMethodParam(Parameter p, ApiCallSite site) {
+        String name = p.getNameAsString();
+        String type = codeType(p.getTypeAsString());
+        if (site != null) {
+            if (expressionReferencesName(apiCallBodyArg(site), name)) {
+                return "the " + type + " request body";
+            }
+            if (expressionReferencesName(apiCallQueryArg(site), name)) {
+                return "the " + type + " query parameters";
+            }
+            if (expressionReferencesName(site.pathArg, name)) {
+                return "the " + type + " path parameter";
+            }
+        }
+        return "the " + type + " " + humanizeIdentifier(name);
+    }
+
+    private static String describeConstructorParam(Parameter p) {
+        String name = p.getNameAsString();
+        String type = p.getTypeAsString();
+        if ("ApiCall".equals(type)) {
+            return "the " + codeType(type) + " instance used to send requests";
+        }
+        if ("Configuration".equals(type)) {
+            return "the client configuration";
+        }
+        if ("OkHttpClient".equals(type)) {
+            return "the HTTP client";
+        }
+        if (name.endsWith("Id") || name.endsWith("Name")) {
+            return "the " + codeType(type) + " path parameter";
+        }
+        return "the " + codeType(type) + " " + humanizeIdentifier(name);
+    }
+
+    private static String describeReturn(MethodDeclaration m) {
+        String type = m.getTypeAsString();
+        if ("String".equals(type)) {
+            return "the raw response body";
+        }
+        if (type.endsWith("[]")) {
+            return "the " + codeType(type) + " response array";
+        }
+        if (type.startsWith("Map<")) {
+            return "the " + codeType(type) + " response map";
+        }
+        return "the " + codeType(type) + " response";
+    }
+
+    private static Expression apiCallBodyArg(ApiCallSite site) {
+        if (!"POST".equals(site.verb) && !"PUT".equals(site.verb) && !"PATCH".equals(site.verb)) {
+            return null;
+        }
+        NodeList<Expression> args = site.call.getArguments();
+        return args.size() > 1 ? args.get(1) : null;
+    }
+
+    private static Expression apiCallQueryArg(ApiCallSite site) {
+        NodeList<Expression> args = site.call.getArguments();
+        if ("GET".equals(site.verb) || "DELETE".equals(site.verb)) {
+            return args.size() > 1 ? args.get(1) : null;
+        }
+        if ("POST".equals(site.verb) || "PUT".equals(site.verb) || "PATCH".equals(site.verb)) {
+            return args.size() > 2 ? args.get(2) : null;
+        }
+        return null;
+    }
+
+    private static boolean expressionReferencesName(Expression expr, String name) {
+        if (expr == null || name == null) return false;
+        for (NameExpr n : expr.findAll(NameExpr.class)) {
+            if (name.equals(n.getNameAsString())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static String codeType(String type) {
+        return "{@code " + type + "}";
+    }
+
+    private static String renderJavadocBlock(List<String> lines, String indent) {
         StringBuilder sb = new StringBuilder();
         sb.append('\n');
         for (String line : lines) {
             if (line.isEmpty()) {
-                sb.append("     *\n");
+                sb.append(indent).append(" *\n");
             } else {
-                sb.append("     * ").append(line).append('\n');
+                sb.append(indent).append(" * ").append(line).append('\n');
             }
         }
-        sb.append("     ");
+        sb.append(indent).append(" ");
         return sb.toString();
+    }
+
+    private static String javadocIndent(Node node) {
+        int depth = 0;
+        Optional<Node> parent = node.getParentNode();
+        while (parent.isPresent()) {
+            Node current = parent.get();
+            if (current instanceof ClassOrInterfaceDeclaration) {
+                depth++;
+            }
+            parent = current.getParentNode();
+        }
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < depth; i++) {
+            sb.append("    ");
+        }
+        return sb.toString();
+    }
+
+    private static String humanizeIdentifier(String identifier) {
+        if (identifier == null || identifier.isEmpty()) return "";
+        String spaced = identifier.replaceAll("([a-z0-9])([A-Z])", "$1 $2")
+                .replace('_', ' ')
+                .replace('-', ' ')
+                .toLowerCase(Locale.ROOT);
+        return sanitizeJavadocText(spaced);
     }
 
     private static String sanitizeJavadocText(String s) {

--- a/generator/src/main/java/org/typesense/docgen/DocGen.java
+++ b/generator/src/main/java/org/typesense/docgen/DocGen.java
@@ -2,6 +2,7 @@ package org.typesense.docgen;
 
 import com.github.javaparser.StaticJavaParser;
 import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.NodeList;
 import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
 import com.github.javaparser.ast.body.ConstructorDeclaration;
@@ -226,6 +227,14 @@ public final class DocGen {
         boolean changed = false;
         for (ClassOrInterfaceDeclaration cls : cu.findAll(ClassOrInterfaceDeclaration.class)) {
             String className = cls.getNameAsString();
+            if (writeClassJavadoc(cls)) {
+                changed = true;
+            }
+            for (ConstructorDeclaration c : cls.getConstructors()) {
+                if (writeConstructorJavadoc(c, className)) {
+                    changed = true;
+                }
+            }
             for (MethodDeclaration m : cls.getMethods()) {
                 if (!m.getBody().isPresent()) continue;
                 ApiCallSite site = findUniqueApiCall(m);
@@ -242,7 +251,7 @@ public final class DocGen {
                             + " -> " + key);
                     continue;
                 }
-                if (writeJavadoc(m, op)) {
+                if (writeJavadoc(m, op, site)) {
                     changed = true;
                 }
             }
@@ -420,6 +429,55 @@ public final class DocGen {
         return path;
     }
 
+    private static boolean writeClassJavadoc(ClassOrInterfaceDeclaration cls) {
+        if (!cls.isPublic()) {
+            return false;
+        }
+        String content = renderClassJavadocContent(cls);
+        if (cls.getJavadocComment().isPresent()) {
+            String existing = cls.getJavadocComment().get().getContent();
+            if (!isGeneratedClassJavadoc(existing)) {
+                return false;
+            }
+            if (normalizeJavadocContent(existing).equals(normalizeJavadocContent(content))) {
+                return false;
+            }
+        }
+        cls.setJavadocComment(content);
+        return true;
+    }
+
+    private static String renderClassJavadocContent(ClassOrInterfaceDeclaration cls) {
+        List<String> lines = new ArrayList<String>();
+        lines.add("Typesense " + humanizeIdentifier(cls.getNameAsString()) + " API wrapper.");
+        return renderJavadocBlock(lines, javadocIndent(cls));
+    }
+
+    private static boolean writeConstructorJavadoc(ConstructorDeclaration c, String className) {
+        if (!c.isPublic()) {
+            return false;
+        }
+        String content = renderConstructorJavadocContent(c, className);
+        if (c.getJavadocComment().isPresent()) {
+            String existing = c.getJavadocComment().get().getContent();
+            if (!isGeneratedConstructorJavadoc(existing)) {
+                return false;
+            }
+            if (normalizeJavadocContent(existing).equals(normalizeJavadocContent(content))) {
+                return false;
+            }
+        }
+        c.setJavadocComment(content);
+        return true;
+    }
+
+    private static String renderConstructorJavadocContent(ConstructorDeclaration c, String className) {
+        List<String> lines = new ArrayList<String>();
+        lines.add("Creates a new " + className + " instance.");
+        addConstructorParamTags(lines, c.getParameters());
+        return renderJavadocBlock(lines, javadocIndent(c));
+    }
+
     private static boolean writeJavadoc(MethodDeclaration m, OpInfo op) {
         String content = renderJavadocContent(op);
         if (m.getJavadocComment().isPresent()) {
@@ -439,6 +497,18 @@ public final class DocGen {
         return content != null
                 && content.contains("HTTP: ")
                 && content.contains("Typesense docs");
+    }
+
+    private static boolean isGeneratedClassJavadoc(String content) {
+        return content != null
+                && content.contains("Typesense ")
+                && content.contains(" API wrapper");
+    }
+
+    private static boolean isGeneratedConstructorJavadoc(String content) {
+        return content != null
+                && content.contains("Creates a new ")
+                && content.contains(" instance.");
     }
 
     private static String normalizeJavadocContent(String content) {

--- a/src/main/java/org/typesense/api/Alias.java
+++ b/src/main/java/org/typesense/api/Alias.java
@@ -3,11 +3,19 @@ package org.typesense.api;
 import org.typesense.api.utils.URLEncoding;
 import org.typesense.model.CollectionAlias;
 
+/**
+ * Typesense alias API wrapper.
+ */
 public class Alias {
 
     public ApiCall apiCall;
     public String name;
 
+    /**
+     * Creates a new Alias instance.
+     * @param apiCall the {@code ApiCall} instance used to send requests
+     * @param name the {@code String} name
+     */
     public Alias(ApiCall apiCall, String name) {
         this.apiCall = apiCall;
         this.name = name;
@@ -22,6 +30,9 @@ public class Alias {
      * <p>
      * HTTP: GET /aliases/{aliasName}
      *
+     * @return the {@code CollectionAlias} response
+     * @throws Exception if the request fails
+     *
      * @see <a href="https://typesense.org/docs/latest/api/collections.html">Typesense docs</a>
      */
     public CollectionAlias retrieve() throws Exception {
@@ -33,6 +44,9 @@ public class Alias {
      *
      * <p>
      * HTTP: DELETE /aliases/{aliasName}
+     *
+     * @return the {@code CollectionAlias} response
+     * @throws Exception if the request fails
      *
      * @see <a href="https://typesense.org/docs/latest/api/collections.html">Typesense docs</a>
      */

--- a/src/main/java/org/typesense/api/Alias.java
+++ b/src/main/java/org/typesense/api/Alias.java
@@ -13,10 +13,29 @@ public class Alias {
         this.name = name;
     }
 
+    /**
+     * Retrieve an alias.
+     *
+     * <p>
+     * Find out which collection an alias points to by fetching it
+     *
+     * <p>
+     * HTTP: GET /aliases/{aliasName}
+     *
+     * @see <a href="https://typesense.org/docs/latest/api/collections.html">Typesense docs</a>
+     */
     public CollectionAlias retrieve() throws Exception {
         return this.apiCall.get(this.getEndpoint(), null, CollectionAlias.class);
     }
 
+    /**
+     * Delete an alias.
+     *
+     * <p>
+     * HTTP: DELETE /aliases/{aliasName}
+     *
+     * @see <a href="https://typesense.org/docs/latest/api/collections.html">Typesense docs</a>
+     */
     public CollectionAlias delete() throws Exception {
         return this.apiCall.delete(this.getEndpoint(), null, CollectionAlias.class);
     }

--- a/src/main/java/org/typesense/api/Aliases.java
+++ b/src/main/java/org/typesense/api/Aliases.java
@@ -5,11 +5,18 @@ import org.typesense.model.CollectionAlias;
 import org.typesense.model.CollectionAliasSchema;
 import org.typesense.model.CollectionAliasesResponse;
 
+/**
+ * Typesense aliases API wrapper.
+ */
 public class Aliases {
 
     private ApiCall apiCall;
     public final static String RESOURCE_PATH = "/aliases";
 
+    /**
+     * Creates a new Aliases instance.
+     * @param apiCall the {@code ApiCall} instance used to send requests
+     */
     public Aliases(ApiCall apiCall) {
         this.apiCall = apiCall;
     }
@@ -22,6 +29,11 @@ public class Aliases {
      *
      * <p>
      * HTTP: PUT /aliases/{aliasName}
+     *
+     * @param name the {@code String} path parameter
+     * @param collectionAliasSchema the {@code CollectionAliasSchema} request body
+     * @return the {@code CollectionAlias} response
+     * @throws Exception if the request fails
      *
      * @see <a href="https://typesense.org/docs/latest/api/collections.html">Typesense docs</a>
      */
@@ -38,6 +50,9 @@ public class Aliases {
      *
      * <p>
      * HTTP: GET /aliases
+     *
+     * @return the {@code CollectionAliasesResponse} response
+     * @throws Exception if the request fails
      *
      * @see <a href="https://typesense.org/docs/latest/api/collections.html">Typesense docs</a>
      */

--- a/src/main/java/org/typesense/api/Aliases.java
+++ b/src/main/java/org/typesense/api/Aliases.java
@@ -14,11 +14,33 @@ public class Aliases {
         this.apiCall = apiCall;
     }
 
+    /**
+     * Create or update a collection alias.
+     *
+     * <p>
+     * Create or update a collection alias. An alias is a virtual collection name that points to a real collection. If you're familiar with symbolic links on Linux, it's very similar to that. Aliases are useful when you want to reindex your data in the background on a new collection and switch your application to it without any changes to your code.
+     *
+     * <p>
+     * HTTP: PUT /aliases/{aliasName}
+     *
+     * @see <a href="https://typesense.org/docs/latest/api/collections.html">Typesense docs</a>
+     */
     public CollectionAlias upsert(String name, CollectionAliasSchema collectionAliasSchema) throws Exception {
         return this.apiCall.put(RESOURCE_PATH + "/" + URLEncoding.encodeURIComponent(name), collectionAliasSchema, null,
                 CollectionAlias.class);
     }
 
+    /**
+     * List all aliases.
+     *
+     * <p>
+     * List all aliases and the corresponding collections that they map to.
+     *
+     * <p>
+     * HTTP: GET /aliases
+     *
+     * @see <a href="https://typesense.org/docs/latest/api/collections.html">Typesense docs</a>
+     */
     public CollectionAliasesResponse retrieve() throws Exception {
         return this.apiCall.get(RESOURCE_PATH, null, CollectionAliasesResponse.class);
     }

--- a/src/main/java/org/typesense/api/Analytics.java
+++ b/src/main/java/org/typesense/api/Analytics.java
@@ -3,12 +3,19 @@ package org.typesense.api;
 import java.util.HashMap;
 import java.util.Map;
 
+/**
+ * Typesense analytics API wrapper.
+ */
 public class Analytics {
     private final ApiCall apiCall;
     private final AnalyticsRules rules;
     private final Map<String, AnalyticsRule> individualRules;
     private final AnalyticsEvents events;
 
+    /**
+     * Creates a new Analytics instance.
+     * @param apiCall the {@code ApiCall} instance used to send requests
+     */
     public Analytics(ApiCall apiCall) {
         this.apiCall = apiCall;
         this.rules = new AnalyticsRules(this.apiCall);

--- a/src/main/java/org/typesense/api/AnalyticsEvents.java
+++ b/src/main/java/org/typesense/api/AnalyticsEvents.java
@@ -5,10 +5,17 @@ import org.typesense.model.AnalyticsEventCreateResponse;
 import org.typesense.model.AnalyticsEventsResponse;
 import java.util.Map;
 
+/**
+ * Typesense analytics events API wrapper.
+ */
 public class AnalyticsEvents {
     private final ApiCall apiCall;
     public final static String RESOURCE_PATH = "/analytics/events";
 
+    /**
+     * Creates a new AnalyticsEvents instance.
+     * @param apiCall the {@code ApiCall} instance used to send requests
+     */
     public AnalyticsEvents(ApiCall apiCall) {
         this.apiCall = apiCall;
     }
@@ -21,6 +28,10 @@ public class AnalyticsEvents {
      *
      * <p>
      * HTTP: POST /analytics/events
+     *
+     * @param event the {@code AnalyticsEvent} request body
+     * @return the {@code AnalyticsEventCreateResponse} response
+     * @throws Exception if the request fails
      *
      * @see <a href="https://typesense.org/docs/latest/api/analytics-query-suggestions.html">Typesense docs</a>
      */
@@ -36,6 +47,10 @@ public class AnalyticsEvents {
      *
      * <p>
      * HTTP: GET /analytics/events
+     *
+     * @param params the {@code Map<String,Object>} query parameters
+     * @return the {@code AnalyticsEventsResponse} response
+     * @throws Exception if the request fails
      *
      * @see <a href="https://typesense.org/docs/latest/api/analytics-query-suggestions.html">Typesense docs</a>
      */

--- a/src/main/java/org/typesense/api/AnalyticsEvents.java
+++ b/src/main/java/org/typesense/api/AnalyticsEvents.java
@@ -13,10 +13,32 @@ public class AnalyticsEvents {
         this.apiCall = apiCall;
     }
 
+    /**
+     * Create an analytics event.
+     *
+     * <p>
+     * Submit a single analytics event. The event must correspond to an existing analytics rule by name.
+     *
+     * <p>
+     * HTTP: POST /analytics/events
+     *
+     * @see <a href="https://typesense.org/docs/latest/api/analytics-query-suggestions.html">Typesense docs</a>
+     */
     public AnalyticsEventCreateResponse create(AnalyticsEvent event) throws Exception {
         return this.apiCall.post(RESOURCE_PATH, event, null, AnalyticsEventCreateResponse.class);
     }
 
+    /**
+     * Retrieve analytics events.
+     *
+     * <p>
+     * Retrieve the most recent events for a user and rule.
+     *
+     * <p>
+     * HTTP: GET /analytics/events
+     *
+     * @see <a href="https://typesense.org/docs/latest/api/analytics-query-suggestions.html">Typesense docs</a>
+     */
     public AnalyticsEventsResponse retrieve(Map<String, Object> params) throws Exception {
         return this.apiCall.get(RESOURCE_PATH, params, AnalyticsEventsResponse.class);
     }

--- a/src/main/java/org/typesense/api/AnalyticsRule.java
+++ b/src/main/java/org/typesense/api/AnalyticsRule.java
@@ -3,17 +3,31 @@ package org.typesense.api;
 import org.typesense.api.utils.URLEncoding;
 import org.typesense.model.AnalyticsRuleUpdate;
 
+/**
+ * Typesense analytics rule API wrapper.
+ */
 public class AnalyticsRule {
     private final ApiCall apiCall;
     private final String ruleId;
     private final AnalyticsRuleSerializer serializer;
 
+    /**
+     * Creates a new AnalyticsRule instance.
+     * @param ruleId the {@code String} path parameter
+     * @param apiCall the {@code ApiCall} instance used to send requests
+     */
     public AnalyticsRule(String ruleId, ApiCall apiCall) {
         this.apiCall = apiCall;
         this.ruleId = ruleId;
         this.serializer = new AnalyticsRuleSerializer();
     }
     
+    /**
+     * Creates a new AnalyticsRule instance.
+     * @param ruleId the {@code String} path parameter
+     * @param apiCall the {@code ApiCall} instance used to send requests
+     * @param serializer the {@code AnalyticsRuleSerializer} serializer
+     */
     public AnalyticsRule(String ruleId, ApiCall apiCall, AnalyticsRuleSerializer serializer) {
         this.apiCall = apiCall;
         this.ruleId = ruleId;
@@ -28,6 +42,9 @@ public class AnalyticsRule {
      *
      * <p>
      * HTTP: GET /analytics/rules/{ruleName}
+     *
+     * @return the {@code org.typesense.model.AnalyticsRule} response
+     * @throws Exception if the request fails
      *
      * @see <a href="https://typesense.org/docs/latest/api/analytics-query-suggestions.html">Typesense docs</a>
      */
@@ -44,6 +61,9 @@ public class AnalyticsRule {
      *
      * <p>
      * HTTP: DELETE /analytics/rules/{ruleName}
+     *
+     * @return the {@code org.typesense.model.AnalyticsRule} response
+     * @throws Exception if the request fails
      *
      * @see <a href="https://typesense.org/docs/latest/api/analytics-query-suggestions.html">Typesense docs</a>
      */
@@ -62,6 +82,10 @@ public class AnalyticsRule {
      *
      * <p>
      * HTTP: PUT /analytics/rules/{ruleName}
+     *
+     * @param rule the {@code AnalyticsRuleUpdate} request body
+     * @return the {@code org.typesense.model.AnalyticsRule} response
+     * @throws Exception if the request fails
      *
      * @see <a href="https://typesense.org/docs/latest/api/analytics-query-suggestions.html">Typesense docs</a>
      */

--- a/src/main/java/org/typesense/api/AnalyticsRule.java
+++ b/src/main/java/org/typesense/api/AnalyticsRule.java
@@ -20,11 +20,33 @@ public class AnalyticsRule {
         this.serializer = serializer;
     }
 
+    /**
+     * Retrieves an analytics rule.
+     *
+     * <p>
+     * Retrieve the details of an analytics rule, given it's name
+     *
+     * <p>
+     * HTTP: GET /analytics/rules/{ruleName}
+     *
+     * @see <a href="https://typesense.org/docs/latest/api/analytics-query-suggestions.html">Typesense docs</a>
+     */
     public org.typesense.model.AnalyticsRule retrieve() throws Exception {
         String response = this.apiCall.get(this.getEndpoint(), null, String.class);
         return serializer.parseFromJson(response);
     }
 
+    /**
+     * Delete an analytics rule.
+     *
+     * <p>
+     * Permanently deletes an analytics rule, given it's name
+     *
+     * <p>
+     * HTTP: DELETE /analytics/rules/{ruleName}
+     *
+     * @see <a href="https://typesense.org/docs/latest/api/analytics-query-suggestions.html">Typesense docs</a>
+     */
     public org.typesense.model.AnalyticsRule delete() throws Exception {
         String response = this.apiCall.delete(this.getEndpoint(), null, String.class);
         org.typesense.model.AnalyticsRule result = new org.typesense.model.AnalyticsRule();
@@ -32,6 +54,17 @@ public class AnalyticsRule {
         return result;
     }
 
+    /**
+     * Upserts an analytics rule.
+     *
+     * <p>
+     * Upserts an analytics rule with the given name.
+     *
+     * <p>
+     * HTTP: PUT /analytics/rules/{ruleName}
+     *
+     * @see <a href="https://typesense.org/docs/latest/api/analytics-query-suggestions.html">Typesense docs</a>
+     */
     public org.typesense.model.AnalyticsRule update(AnalyticsRuleUpdate rule) throws Exception {
         return this.apiCall.put(this.getEndpoint(), rule, null, org.typesense.model.AnalyticsRule.class);
     }

--- a/src/main/java/org/typesense/api/AnalyticsRuleSerializer.java
+++ b/src/main/java/org/typesense/api/AnalyticsRuleSerializer.java
@@ -17,6 +17,9 @@ public class AnalyticsRuleSerializer {
     
     private final ObjectMapper objectMapper;
     
+    /**
+     * Creates a new AnalyticsRuleSerializer instance.
+     */
     public AnalyticsRuleSerializer() {
         this.objectMapper = new ObjectMapper();
         this.objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);

--- a/src/main/java/org/typesense/api/AnalyticsRules.java
+++ b/src/main/java/org/typesense/api/AnalyticsRules.java
@@ -20,11 +20,33 @@ public class AnalyticsRules {
         this.serializer = serializer;
     }
 
+    /**
+     * Create analytics rule(s).
+     *
+     * <p>
+     * Create one or more analytics rules. You can send a single rule object or an array of rule objects.
+     *
+     * <p>
+     * HTTP: POST /analytics/rules
+     *
+     * @see <a href="https://typesense.org/docs/latest/api/analytics-query-suggestions.html">Typesense docs</a>
+     */
     public AnalyticsRulesResponse create(List<AnalyticsRuleCreate> rules) throws Exception {
         String response = this.apiCall.post(RESOURCE_PATH, rules, null, String.class);
         return parseCreateResponse(response);
     }
 
+    /**
+     * Retrieve analytics rules.
+     *
+     * <p>
+     * Retrieve all analytics rules. Use the optional rule_tag filter to narrow down results.
+     *
+     * <p>
+     * HTTP: GET /analytics/rules
+     *
+     * @see <a href="https://typesense.org/docs/latest/api/analytics-query-suggestions.html">Typesense docs</a>
+     */
     public List<AnalyticsRule> retrieve() throws Exception {
         String response = this.apiCall.get(RESOURCE_PATH, null, String.class);
         return parseRetrieveResponse(response);

--- a/src/main/java/org/typesense/api/AnalyticsRules.java
+++ b/src/main/java/org/typesense/api/AnalyticsRules.java
@@ -4,17 +4,29 @@ import org.typesense.model.AnalyticsRule;
 import org.typesense.model.AnalyticsRuleCreate;
 import java.util.List;
 
+/**
+ * Typesense analytics rules API wrapper.
+ */
 public class AnalyticsRules {
 
     private final ApiCall apiCall;
     private final AnalyticsRuleSerializer serializer;
     public final static String RESOURCE_PATH = "/analytics/rules";
 
+    /**
+     * Creates a new AnalyticsRules instance.
+     * @param apiCall the {@code ApiCall} instance used to send requests
+     */
     public AnalyticsRules(ApiCall apiCall) {
         this.apiCall = apiCall;
         this.serializer = new AnalyticsRuleSerializer();
     }
     
+    /**
+     * Creates a new AnalyticsRules instance.
+     * @param apiCall the {@code ApiCall} instance used to send requests
+     * @param serializer the {@code AnalyticsRuleSerializer} serializer
+     */
     public AnalyticsRules(ApiCall apiCall, AnalyticsRuleSerializer serializer) {
         this.apiCall = apiCall;
         this.serializer = serializer;
@@ -28,6 +40,10 @@ public class AnalyticsRules {
      *
      * <p>
      * HTTP: POST /analytics/rules
+     *
+     * @param rules the {@code List<AnalyticsRuleCreate>} request body
+     * @return the {@code AnalyticsRulesResponse} response
+     * @throws Exception if the request fails
      *
      * @see <a href="https://typesense.org/docs/latest/api/analytics-query-suggestions.html">Typesense docs</a>
      */
@@ -44,6 +60,9 @@ public class AnalyticsRules {
      *
      * <p>
      * HTTP: GET /analytics/rules
+     *
+     * @return the {@code List<AnalyticsRule>} response
+     * @throws Exception if the request fails
      *
      * @see <a href="https://typesense.org/docs/latest/api/analytics-query-suggestions.html">Typesense docs</a>
      */
@@ -82,6 +101,10 @@ public class AnalyticsRules {
     public static class AnalyticsRulesResponse {
         private final List<AnalyticsRule> rules;
 
+        /**
+         * Creates a new AnalyticsRulesResponse instance.
+         * @param rules the {@code List<AnalyticsRule>} rules
+         */
         public AnalyticsRulesResponse(List<AnalyticsRule> rules) {
             this.rules = rules;
         }

--- a/src/main/java/org/typesense/api/ApiCall.java
+++ b/src/main/java/org/typesense/api/ApiCall.java
@@ -19,6 +19,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
+/**
+ * Typesense api call API wrapper.
+ */
 public class ApiCall {
 
     private final Configuration configuration;
@@ -35,6 +38,11 @@ public class ApiCall {
     public static final MediaType JSON = MediaType.parse("application/json; charset=utf-8");
     private final ObjectMapper mapper = new ObjectMapper();
 
+    /**
+     * Creates a new ApiCall instance.
+     * @param configuration the client configuration
+     * @param client the HTTP client
+     */
     public ApiCall(Configuration configuration, OkHttpClient client) {
         this.configuration = configuration;
         this.nodes = configuration.nodes;
@@ -47,6 +55,10 @@ public class ApiCall {
         this.client = client;
     }
 
+    /**
+     * Creates a new ApiCall instance.
+     * @param configuration the client configuration
+     */
     public ApiCall(Configuration configuration) {
         this.configuration = configuration;
         this.nodes = configuration.nodes;

--- a/src/main/java/org/typesense/api/Client.java
+++ b/src/main/java/org/typesense/api/Client.java
@@ -6,6 +6,9 @@ import okhttp3.OkHttpClient;
 import java.util.HashMap;
 import java.util.Map;
 
+/**
+ * Typesense client API wrapper.
+ */
 public class Client {
     private Configuration configuration;
 
@@ -40,6 +43,11 @@ public class Client {
     public Debug debug;
     public MultiSearch multiSearch;
 
+    /**
+     * Creates a new Client instance.
+     * @param configuration the client configuration
+     * @param okHttpClient the HTTP client
+     */
     public Client(Configuration configuration, OkHttpClient okHttpClient){
         this.configuration = configuration;
         this.apiCall = new ApiCall(configuration, okHttpClient);
@@ -60,6 +68,10 @@ public class Client {
         this.individualStopwordsSets = new HashMap<>();
     }
 
+    /**
+     * Creates a new Client instance.
+     * @param configuration the client configuration
+     */
     public Client(Configuration configuration){
         this.configuration = configuration;
         this.apiCall = new ApiCall(configuration);

--- a/src/main/java/org/typesense/api/Collection.java
+++ b/src/main/java/org/typesense/api/Collection.java
@@ -34,14 +34,47 @@ public class Collection {
         this.individualSynonyms = new HashMap<>();
     }
 
+    /**
+     * Retrieve a single collection.
+     *
+     * <p>
+     * Retrieve the details of a collection, given its name.
+     *
+     * <p>
+     * HTTP: GET /collections/{collectionName}
+     *
+     * @see <a href="https://typesense.org/docs/latest/api/collections.html">Typesense docs</a>
+     */
     public CollectionResponse retrieve() throws Exception {
         return this.apiCall.get(endpoint, null, CollectionResponse.class);
     }
 
+    /**
+     * Update a collection.
+     *
+     * <p>
+     * Update a collection's schema to modify the fields and their types.
+     *
+     * <p>
+     * HTTP: PATCH /collections/{collectionName}
+     *
+     * @see <a href="https://typesense.org/docs/latest/api/collections.html">Typesense docs</a>
+     */
     public CollectionUpdateSchema update(CollectionUpdateSchema c) throws Exception {
         return this.apiCall.patch(endpoint, c, null, CollectionUpdateSchema.class);
     }
 
+    /**
+     * Delete a collection.
+     *
+     * <p>
+     * Permanently drops a collection. This action cannot be undone. For large collections, this might have an impact on read latencies.
+     *
+     * <p>
+     * HTTP: DELETE /collections/{collectionName}
+     *
+     * @see <a href="https://typesense.org/docs/latest/api/collections.html">Typesense docs</a>
+     */
     public CollectionResponse delete() throws Exception {
         return this.apiCall.delete(endpoint, null, CollectionResponse.class);
     }

--- a/src/main/java/org/typesense/api/Collection.java
+++ b/src/main/java/org/typesense/api/Collection.java
@@ -7,6 +7,9 @@ import org.typesense.model.CollectionUpdateSchema;
 import java.util.HashMap;
 import java.util.Map;
 
+/**
+ * Typesense collection API wrapper.
+ */
 public class Collection {
 
     private final Configuration configuration;
@@ -43,6 +46,9 @@ public class Collection {
      * <p>
      * HTTP: GET /collections/{collectionName}
      *
+     * @return the {@code CollectionResponse} response
+     * @throws Exception if the request fails
+     *
      * @see <a href="https://typesense.org/docs/latest/api/collections.html">Typesense docs</a>
      */
     public CollectionResponse retrieve() throws Exception {
@@ -58,6 +64,10 @@ public class Collection {
      * <p>
      * HTTP: PATCH /collections/{collectionName}
      *
+     * @param c the {@code CollectionUpdateSchema} request body
+     * @return the {@code CollectionUpdateSchema} response
+     * @throws Exception if the request fails
+     *
      * @see <a href="https://typesense.org/docs/latest/api/collections.html">Typesense docs</a>
      */
     public CollectionUpdateSchema update(CollectionUpdateSchema c) throws Exception {
@@ -72,6 +82,9 @@ public class Collection {
      *
      * <p>
      * HTTP: DELETE /collections/{collectionName}
+     *
+     * @return the {@code CollectionResponse} response
+     * @throws Exception if the request fails
      *
      * @see <a href="https://typesense.org/docs/latest/api/collections.html">Typesense docs</a>
      */

--- a/src/main/java/org/typesense/api/Collections.java
+++ b/src/main/java/org/typesense/api/Collections.java
@@ -3,11 +3,18 @@ package org.typesense.api;
 import org.typesense.model.CollectionResponse;
 import org.typesense.model.CollectionSchema;
 
+/**
+ * Typesense collections API wrapper.
+ */
 public class Collections {
 
     private final ApiCall apiCall;
     public final static String RESOURCE_PATH = "/collections";
 
+    /**
+     * Creates a new Collections instance.
+     * @param apiCall the {@code ApiCall} instance used to send requests
+     */
     public Collections(ApiCall apiCall){
         this.apiCall = apiCall;
     }
@@ -20,6 +27,10 @@ public class Collections {
      *
      * <p>
      * HTTP: POST /collections
+     *
+     * @param c the {@code CollectionSchema} request body
+     * @return the {@code CollectionResponse} response
+     * @throws Exception if the request fails
      *
      * @see <a href="https://typesense.org/docs/latest/api/collections.html">Typesense docs</a>
      */
@@ -36,6 +47,10 @@ public class Collections {
      * <p>
      * HTTP: POST /collections
      *
+     * @param schemaJson the {@code String} request body
+     * @return the {@code CollectionResponse} response
+     * @throws Exception if the request fails
+     *
      * @see <a href="https://typesense.org/docs/latest/api/collections.html">Typesense docs</a>
      */
     public CollectionResponse create(String schemaJson) throws Exception {
@@ -50,6 +65,9 @@ public class Collections {
      *
      * <p>
      * HTTP: GET /collections
+     *
+     * @return the {@code CollectionResponse[]} response array
+     * @throws Exception if the request fails
      *
      * @see <a href="https://typesense.org/docs/latest/api/collections.html">Typesense docs</a>
      */

--- a/src/main/java/org/typesense/api/Collections.java
+++ b/src/main/java/org/typesense/api/Collections.java
@@ -12,14 +12,47 @@ public class Collections {
         this.apiCall = apiCall;
     }
 
+    /**
+     * Create a new collection.
+     *
+     * <p>
+     * When a collection is created, we give it a name and describe the fields that will be indexed from the documents added to the collection.
+     *
+     * <p>
+     * HTTP: POST /collections
+     *
+     * @see <a href="https://typesense.org/docs/latest/api/collections.html">Typesense docs</a>
+     */
     public CollectionResponse create(CollectionSchema c) throws Exception {
         return this.apiCall.post(RESOURCE_PATH, c, null, CollectionResponse.class);
     }
 
+    /**
+     * Create a new collection.
+     *
+     * <p>
+     * When a collection is created, we give it a name and describe the fields that will be indexed from the documents added to the collection.
+     *
+     * <p>
+     * HTTP: POST /collections
+     *
+     * @see <a href="https://typesense.org/docs/latest/api/collections.html">Typesense docs</a>
+     */
     public CollectionResponse create(String schemaJson) throws Exception {
         return this.apiCall.post(RESOURCE_PATH, schemaJson, null, CollectionResponse.class);
     }
 
+    /**
+     * List all collections.
+     *
+     * <p>
+     * Returns a summary of all your collections. The collections are returned sorted by creation date, with the most recent collections appearing first.
+     *
+     * <p>
+     * HTTP: GET /collections
+     *
+     * @see <a href="https://typesense.org/docs/latest/api/collections.html">Typesense docs</a>
+     */
     public CollectionResponse[] retrieve() throws Exception {
         return this.apiCall.get(RESOURCE_PATH, null, CollectionResponse[].class);
     }

--- a/src/main/java/org/typesense/api/Configuration.java
+++ b/src/main/java/org/typesense/api/Configuration.java
@@ -5,6 +5,9 @@ import org.typesense.resources.Node;
 import java.time.Duration;
 import java.util.List;
 
+/**
+ * Typesense configuration API wrapper.
+ */
 public class Configuration {
 
     public List<Node> nodes;
@@ -24,6 +27,12 @@ public class Configuration {
      * @param apiKey String describing the apiKey
      */
 
+    /**
+     * Creates a new Configuration instance.
+     * @param nodes the {@code List<Node>} nodes
+     * @param connectionTimeout the {@code Duration} connection timeout
+     * @param apiKey the {@code String} api key
+     */
     public Configuration(List<Node> nodes, Duration connectionTimeout, String apiKey) {
         this.nodes = nodes;
         this.connectionTimeout = connectionTimeout;
@@ -55,6 +64,13 @@ public class Configuration {
         this.sendApiKeyAsQueryParam = false;
     }
 
+    /**
+     * Creates a new Configuration instance.
+     * @param nearestNode the {@code Node} nearest node
+     * @param nodes the {@code List<Node>} nodes
+     * @param connectionTimeout the {@code Duration} connection timeout
+     * @param apiKey the {@code String} api key
+     */
     public Configuration(Node nearestNode, List<Node> nodes, Duration connectionTimeout, String apiKey) {
         this(nodes,connectionTimeout,apiKey);
         this.nearestNode = nearestNode;

--- a/src/main/java/org/typesense/api/CurationSet.java
+++ b/src/main/java/org/typesense/api/CurationSet.java
@@ -5,11 +5,19 @@ import org.typesense.model.CurationSetCreateSchema;
 import org.typesense.model.CurationSetSchema;
 import org.typesense.model.CurationSetDeleteSchema;
 
+/**
+ * Typesense curation set API wrapper.
+ */
 public class CurationSet {
 
     private String curationSetName;
     private ApiCall apiCall;
 
+    /**
+     * Creates a new CurationSet instance.
+     * @param curationSetName the {@code String} path parameter
+     * @param apiCall the {@code ApiCall} instance used to send requests
+     */
     public CurationSet(String curationSetName, ApiCall apiCall) {
         this.curationSetName = curationSetName;
         this.apiCall = apiCall;
@@ -23,6 +31,9 @@ public class CurationSet {
      *
      * <p>
      * HTTP: GET /curation_sets/{curationSetName}
+     *
+     * @return the {@code CurationSetCreateSchema} response
+     * @throws Exception if the request fails
      *
      * @see <a href="https://typesense.org/docs/latest/api/curation.html">Typesense docs</a>
      */
@@ -39,6 +50,10 @@ public class CurationSet {
      * <p>
      * HTTP: PUT /curation_sets/{curationSetName}
      *
+     * @param curationSetCreateSchema the {@code CurationSetCreateSchema} request body
+     * @return the {@code CurationSetSchema} response
+     * @throws Exception if the request fails
+     *
      * @see <a href="https://typesense.org/docs/latest/api/curation.html">Typesense docs</a>
      */
     public CurationSetSchema upsert(CurationSetCreateSchema curationSetCreateSchema) throws Exception {
@@ -53,6 +68,9 @@ public class CurationSet {
      *
      * <p>
      * HTTP: DELETE /curation_sets/{curationSetName}
+     *
+     * @return the {@code CurationSetDeleteSchema} response
+     * @throws Exception if the request fails
      *
      * @see <a href="https://typesense.org/docs/latest/api/curation.html">Typesense docs</a>
      */

--- a/src/main/java/org/typesense/api/CurationSet.java
+++ b/src/main/java/org/typesense/api/CurationSet.java
@@ -15,14 +15,47 @@ public class CurationSet {
         this.apiCall = apiCall;
     }
 
+    /**
+     * Retrieve a curation set.
+     *
+     * <p>
+     * Retrieve a specific curation set by its name
+     *
+     * <p>
+     * HTTP: GET /curation_sets/{curationSetName}
+     *
+     * @see <a href="https://typesense.org/docs/latest/api/curation.html">Typesense docs</a>
+     */
     public CurationSetCreateSchema retrieve() throws Exception {
         return this.apiCall.get(this.getEndpoint(), null, CurationSetCreateSchema.class);
     }
 
+    /**
+     * Create or update a curation set.
+     *
+     * <p>
+     * Create or update a curation set with the given name
+     *
+     * <p>
+     * HTTP: PUT /curation_sets/{curationSetName}
+     *
+     * @see <a href="https://typesense.org/docs/latest/api/curation.html">Typesense docs</a>
+     */
     public CurationSetSchema upsert(CurationSetCreateSchema curationSetCreateSchema) throws Exception {
         return this.apiCall.put(this.getEndpoint(), curationSetCreateSchema, null, CurationSetSchema.class);
     }
 
+    /**
+     * Delete a curation set.
+     *
+     * <p>
+     * Delete a specific curation set by its name
+     *
+     * <p>
+     * HTTP: DELETE /curation_sets/{curationSetName}
+     *
+     * @see <a href="https://typesense.org/docs/latest/api/curation.html">Typesense docs</a>
+     */
     public CurationSetDeleteSchema delete() throws Exception {
         return this.apiCall.delete(this.getEndpoint(), null, CurationSetDeleteSchema.class);
     }

--- a/src/main/java/org/typesense/api/CurationSets.java
+++ b/src/main/java/org/typesense/api/CurationSets.java
@@ -3,11 +3,18 @@ package org.typesense.api;
 import org.typesense.model.CurationSetCreateSchema;
 import org.typesense.model.CurationSetSchema;
 
+/**
+ * Typesense curation sets API wrapper.
+ */
 public class CurationSets {
 
     private ApiCall apiCall;
     public final static String RESOURCEPATH = "/curation_sets";
 
+    /**
+     * Creates a new CurationSets instance.
+     * @param apiCall the {@code ApiCall} instance used to send requests
+     */
     public CurationSets(ApiCall apiCall) {
         this.apiCall = apiCall;
     }
@@ -20,6 +27,11 @@ public class CurationSets {
      *
      * <p>
      * HTTP: PUT /curation_sets/{curationSetName}
+     *
+     * @param curationSetName the {@code String} path parameter
+     * @param curationSetCreateSchema the {@code CurationSetCreateSchema} request body
+     * @return the {@code CurationSetSchema} response
+     * @throws Exception if the request fails
      *
      * @see <a href="https://typesense.org/docs/latest/api/curation.html">Typesense docs</a>
      */
@@ -35,6 +47,9 @@ public class CurationSets {
      *
      * <p>
      * HTTP: GET /curation_sets/{curationSetName}
+     *
+     * @return the {@code CurationSetSchema[]} response array
+     * @throws Exception if the request fails
      *
      * @see <a href="https://typesense.org/docs/latest/api/curation.html">Typesense docs</a>
      */

--- a/src/main/java/org/typesense/api/CurationSets.java
+++ b/src/main/java/org/typesense/api/CurationSets.java
@@ -12,10 +12,32 @@ public class CurationSets {
         this.apiCall = apiCall;
     }
 
+    /**
+     * Create or update a curation set.
+     *
+     * <p>
+     * Create or update a curation set with the given name
+     *
+     * <p>
+     * HTTP: PUT /curation_sets/{curationSetName}
+     *
+     * @see <a href="https://typesense.org/docs/latest/api/curation.html">Typesense docs</a>
+     */
     public CurationSetSchema upsert(String curationSetName, CurationSetCreateSchema curationSetCreateSchema) throws Exception {
         return this.apiCall.put(getEndpoint(curationSetName), curationSetCreateSchema, null, CurationSetSchema.class);
     }
 
+    /**
+     * Retrieve a curation set.
+     *
+     * <p>
+     * Retrieve a specific curation set by its name
+     *
+     * <p>
+     * HTTP: GET /curation_sets/{curationSetName}
+     *
+     * @see <a href="https://typesense.org/docs/latest/api/curation.html">Typesense docs</a>
+     */
     public CurationSetSchema[] retrieve() throws Exception {
         return this.apiCall.get(this.getEndpoint(null), null, CurationSetSchema[].class);
     }

--- a/src/main/java/org/typesense/api/Debug.java
+++ b/src/main/java/org/typesense/api/Debug.java
@@ -2,11 +2,18 @@ package org.typesense.api;
 
 import java.util.Map;
 
+/**
+ * Typesense debug API wrapper.
+ */
 public class Debug {
 
     private ApiCall apiCall;
     public static final String RESOURCEPATH = "/debug";
 
+    /**
+     * Creates a new Debug instance.
+     * @param apiCall the {@code ApiCall} instance used to send requests
+     */
     public Debug(ApiCall apiCall) {
         this.apiCall = apiCall;
     }
@@ -16,6 +23,9 @@ public class Debug {
      *
      * <p>
      * HTTP: GET /debug
+     *
+     * @return the {@code Map<String,Object>} response map
+     * @throws Exception if the request fails
      *
      * @see <a href="https://typesense.org/docs/latest/api/cluster-operations.html#debug">Typesense docs</a>
      */

--- a/src/main/java/org/typesense/api/Debug.java
+++ b/src/main/java/org/typesense/api/Debug.java
@@ -11,6 +11,14 @@ public class Debug {
         this.apiCall = apiCall;
     }
 
+    /**
+     * Print debugging information.
+     *
+     * <p>
+     * HTTP: GET /debug
+     *
+     * @see <a href="https://typesense.org/docs/latest/api/cluster-operations.html#debug">Typesense docs</a>
+     */
     public Map<String, Object> retrieve() throws Exception {
         return this.apiCall.get(RESOURCEPATH, null, Map.class);
     }

--- a/src/main/java/org/typesense/api/Document.java
+++ b/src/main/java/org/typesense/api/Document.java
@@ -18,14 +18,47 @@ public class Document {
                 + Documents.RESOURCE_PATH + "/" + URLEncoding.encodeURIComponent(this.documentId);
     }
 
+    /**
+     * Retrieve a document.
+     *
+     * <p>
+     * Fetch an individual document from a collection by using its ID.
+     *
+     * <p>
+     * HTTP: GET /collections/{collectionName}/documents/{documentId}
+     *
+     * @see <a href="https://typesense.org/docs/latest/api/documents.html">Typesense docs</a>
+     */
     public Map<String, Object> retrieve() throws Exception {
         return this.apiCall.get(endpoint, null, Map.class);
     }
 
+    /**
+     * Delete a document.
+     *
+     * <p>
+     * Delete an individual document from a collection by using its ID.
+     *
+     * <p>
+     * HTTP: DELETE /collections/{collectionName}/documents/{documentId}
+     *
+     * @see <a href="https://typesense.org/docs/latest/api/documents.html">Typesense docs</a>
+     */
     public Map<String, Object> delete() throws Exception {
         return this.apiCall.delete(this.endpoint, null, Map.class);
     }
 
+    /**
+     * Update a document.
+     *
+     * <p>
+     * Update an individual document from a collection by using its ID. The update can be partial.
+     *
+     * <p>
+     * HTTP: PATCH /collections/{collectionName}/documents/{documentId}
+     *
+     * @see <a href="https://typesense.org/docs/latest/api/documents.html">Typesense docs</a>
+     */
     public Map<String, Object> update(Map<String, Object> document) throws Exception {
         return this.apiCall.patch(this.endpoint, document, null, Map.class);
     }

--- a/src/main/java/org/typesense/api/Document.java
+++ b/src/main/java/org/typesense/api/Document.java
@@ -3,6 +3,9 @@ package org.typesense.api;
 import java.util.Map;
 import org.typesense.api.utils.URLEncoding;
 
+/**
+ * Typesense document API wrapper.
+ */
 public class Document {
     private String collectionName;
     private String documentId;
@@ -27,6 +30,9 @@ public class Document {
      * <p>
      * HTTP: GET /collections/{collectionName}/documents/{documentId}
      *
+     * @return the {@code Map<String,Object>} response map
+     * @throws Exception if the request fails
+     *
      * @see <a href="https://typesense.org/docs/latest/api/documents.html">Typesense docs</a>
      */
     public Map<String, Object> retrieve() throws Exception {
@@ -42,6 +48,9 @@ public class Document {
      * <p>
      * HTTP: DELETE /collections/{collectionName}/documents/{documentId}
      *
+     * @return the {@code Map<String,Object>} response map
+     * @throws Exception if the request fails
+     *
      * @see <a href="https://typesense.org/docs/latest/api/documents.html">Typesense docs</a>
      */
     public Map<String, Object> delete() throws Exception {
@@ -56,6 +65,10 @@ public class Document {
      *
      * <p>
      * HTTP: PATCH /collections/{collectionName}/documents/{documentId}
+     *
+     * @param document the {@code Map<String,Object>} request body
+     * @return the {@code Map<String,Object>} response map
+     * @throws Exception if the request fails
      *
      * @see <a href="https://typesense.org/docs/latest/api/documents.html">Typesense docs</a>
      */

--- a/src/main/java/org/typesense/api/Documents.java
+++ b/src/main/java/org/typesense/api/Documents.java
@@ -15,6 +15,9 @@ import org.typesense.model.SearchParameters;
 import org.typesense.model.SearchResult;
 import org.typesense.model.UpdateDocumentsParameters;
 
+/**
+ * Typesense documents API wrapper.
+ */
 public class Documents {
 
     private String collectionName;
@@ -38,6 +41,10 @@ public class Documents {
      * <p>
      * HTTP: POST /collections/{collectionName}/documents
      *
+     * @param document the {@code Map<String,Object>} request body
+     * @return the {@code Map<String,Object>} response map
+     * @throws Exception if the request fails
+     *
      * @see <a href="https://typesense.org/docs/latest/api/documents.html">Typesense docs</a>
      */
     public Map<String, Object> create(Map<String, Object> document) throws Exception {
@@ -52,6 +59,10 @@ public class Documents {
      *
      * <p>
      * HTTP: POST /collections/{collectionName}/documents
+     *
+     * @param document the {@code String} request body
+     * @return the raw response body
+     * @throws Exception if the request fails
      *
      * @see <a href="https://typesense.org/docs/latest/api/documents.html">Typesense docs</a>
      */
@@ -68,6 +79,11 @@ public class Documents {
      * <p>
      * HTTP: POST /collections/{collectionName}/documents
      *
+     * @param document the {@code Map<String,Object>} request body
+     * @param queryParameters the {@code ImportDocumentsParameters} query parameters
+     * @return the raw response body
+     * @throws Exception if the request fails
+     *
      * @see <a href="https://typesense.org/docs/latest/api/documents.html">Typesense docs</a>
      */
     public String create(Map<String, Object> document, ImportDocumentsParameters queryParameters) throws Exception {
@@ -82,6 +98,10 @@ public class Documents {
      *
      * <p>
      * HTTP: POST /collections/{collectionName}/documents
+     *
+     * @param document the {@code Map<String,Object>} request body
+     * @return the {@code Map<String,Object>} response map
+     * @throws Exception if the request fails
      *
      * @see <a href="https://typesense.org/docs/latest/api/documents.html">Typesense docs</a>
      */
@@ -101,6 +121,10 @@ public class Documents {
      * <p>
      * HTTP: GET /collections/{collectionName}/documents/search
      *
+     * @param searchParameters the {@code SearchParameters} query parameters
+     * @return the {@code SearchResult} response
+     * @throws Exception if the request fails
+     *
      * @see <a href="https://typesense.org/docs/latest/api/documents.html">Typesense docs</a>
      */
     public SearchResult search(SearchParameters searchParameters) throws Exception {
@@ -115,6 +139,10 @@ public class Documents {
      *
      * <p>
      * HTTP: DELETE /collections/{collectionName}/documents
+     *
+     * @param queryParameters the {@code DeleteDocumentsParameters} query parameters
+     * @return the {@code Map<String,Object>} response map
+     * @throws Exception if the request fails
      *
      * @see <a href="https://typesense.org/docs/latest/api/documents.html">Typesense docs</a>
      */
@@ -131,6 +159,9 @@ public class Documents {
      * <p>
      * HTTP: GET /collections/{collectionName}/documents/export
      *
+     * @return the raw response body
+     * @throws Exception if the request fails
+     *
      * @see <a href="https://typesense.org/docs/latest/api/documents.html">Typesense docs</a>
      */
     public String export() throws Exception {
@@ -145,6 +176,10 @@ public class Documents {
      *
      * <p>
      * HTTP: GET /collections/{collectionName}/documents/export
+     *
+     * @param exportDocumentsParameters the {@code ExportDocumentsParameters} query parameters
+     * @return the raw response body
+     * @throws Exception if the request fails
      *
      * @see <a href="https://typesense.org/docs/latest/api/documents.html">Typesense docs</a>
      */
@@ -161,6 +196,11 @@ public class Documents {
      * <p>
      * HTTP: POST /collections/{collectionName}/documents/import
      *
+     * @param document the {@code String} request body
+     * @param queryParameters the {@code ImportDocumentsParameters} query parameters
+     * @return the raw response body
+     * @throws Exception if the request fails
+     *
      * @see <a href="https://typesense.org/docs/latest/api/documents.html">Typesense docs</a>
      */
     public String import_(String document, ImportDocumentsParameters queryParameters) throws Exception {
@@ -175,6 +215,11 @@ public class Documents {
      *
      * <p>
      * HTTP: POST /collections/{collectionName}/documents/import
+     *
+     * @param documents the {@code Collection<?>} documents
+     * @param queryParameters the {@code ImportDocumentsParameters} query parameters
+     * @return the raw response body
+     * @throws Exception if the request fails
      *
      * @see <a href="https://typesense.org/docs/latest/api/documents.html">Typesense docs</a>
      */

--- a/src/main/java/org/typesense/api/Documents.java
+++ b/src/main/java/org/typesense/api/Documents.java
@@ -29,18 +29,62 @@ public class Documents {
         this.configuration = configuration;
     }
 
+    /**
+     * Index a document.
+     *
+     * <p>
+     * A document to be indexed in a given collection must conform to the schema of the collection.
+     *
+     * <p>
+     * HTTP: POST /collections/{collectionName}/documents
+     *
+     * @see <a href="https://typesense.org/docs/latest/api/documents.html">Typesense docs</a>
+     */
     public Map<String, Object> create(Map<String, Object> document) throws Exception {
         return this.apiCall.post(getEndPoint("/"), document, null, Map.class);
     }
 
+    /**
+     * Index a document.
+     *
+     * <p>
+     * A document to be indexed in a given collection must conform to the schema of the collection.
+     *
+     * <p>
+     * HTTP: POST /collections/{collectionName}/documents
+     *
+     * @see <a href="https://typesense.org/docs/latest/api/documents.html">Typesense docs</a>
+     */
     public String create(String document) throws Exception {
         return this.apiCall.post(getEndPoint("/"), document, null, String.class);
     }
 
+    /**
+     * Index a document.
+     *
+     * <p>
+     * A document to be indexed in a given collection must conform to the schema of the collection.
+     *
+     * <p>
+     * HTTP: POST /collections/{collectionName}/documents
+     *
+     * @see <a href="https://typesense.org/docs/latest/api/documents.html">Typesense docs</a>
+     */
     public String create(Map<String, Object> document, ImportDocumentsParameters queryParameters) throws Exception {
         return this.apiCall.post(getEndPoint("/"), document, queryParameters, String.class);
     }
 
+    /**
+     * Index a document.
+     *
+     * <p>
+     * A document to be indexed in a given collection must conform to the schema of the collection.
+     *
+     * <p>
+     * HTTP: POST /collections/{collectionName}/documents
+     *
+     * @see <a href="https://typesense.org/docs/latest/api/documents.html">Typesense docs</a>
+     */
     public Map<String, Object> upsert(Map<String, Object> document) throws Exception {
         ImportDocumentsParameters queryParameters = new ImportDocumentsParameters();
         queryParameters.action(IndexAction.UPSERT);
@@ -48,26 +92,92 @@ public class Documents {
         return this.apiCall.post(getEndPoint("/"), document, queryParameters, Map.class);
     }
 
+    /**
+     * Search for documents in a collection.
+     *
+     * <p>
+     * Search for documents in a collection that match the search criteria.
+     *
+     * <p>
+     * HTTP: GET /collections/{collectionName}/documents/search
+     *
+     * @see <a href="https://typesense.org/docs/latest/api/documents.html">Typesense docs</a>
+     */
     public SearchResult search(SearchParameters searchParameters) throws Exception {
         return this.apiCall.get(getEndPoint("search"), searchParameters, org.typesense.model.SearchResult.class);
     }
 
+    /**
+     * Delete a bunch of documents.
+     *
+     * <p>
+     * Delete a bunch of documents that match a specific filter condition. Use the `batch_size` parameter to control the number of documents that should deleted at a time. A larger value will speed up deletions, but will impact performance of other operations running on the server.
+     *
+     * <p>
+     * HTTP: DELETE /collections/{collectionName}/documents
+     *
+     * @see <a href="https://typesense.org/docs/latest/api/documents.html">Typesense docs</a>
+     */
     public Map<String, Object> delete(DeleteDocumentsParameters queryParameters) throws Exception {
         return this.apiCall.delete(getEndPoint("/"), queryParameters, Map.class);
     }
 
+    /**
+     * Export all documents in a collection.
+     *
+     * <p>
+     * Export all documents in a collection in JSON lines format.
+     *
+     * <p>
+     * HTTP: GET /collections/{collectionName}/documents/export
+     *
+     * @see <a href="https://typesense.org/docs/latest/api/documents.html">Typesense docs</a>
+     */
     public String export() throws Exception {
         return this.apiCall.get(getEndPoint("export"), null, String.class);
     }
 
+    /**
+     * Export all documents in a collection.
+     *
+     * <p>
+     * Export all documents in a collection in JSON lines format.
+     *
+     * <p>
+     * HTTP: GET /collections/{collectionName}/documents/export
+     *
+     * @see <a href="https://typesense.org/docs/latest/api/documents.html">Typesense docs</a>
+     */
     public String export(ExportDocumentsParameters exportDocumentsParameters) throws Exception {
         return this.apiCall.get(getEndPoint("export"), exportDocumentsParameters, String.class);
     }
 
+    /**
+     * Import documents into a collection.
+     *
+     * <p>
+     * The documents to be imported must be formatted in a newline delimited JSON structure. You can feed the output file from a Typesense export operation directly as import.
+     *
+     * <p>
+     * HTTP: POST /collections/{collectionName}/documents/import
+     *
+     * @see <a href="https://typesense.org/docs/latest/api/documents.html">Typesense docs</a>
+     */
     public String import_(String document, ImportDocumentsParameters queryParameters) throws Exception {
         return this.apiCall.post(this.getEndPoint("import"), document, queryParameters, String.class);
     }
 
+    /**
+     * Import documents into a collection.
+     *
+     * <p>
+     * The documents to be imported must be formatted in a newline delimited JSON structure. You can feed the output file from a Typesense export operation directly as import.
+     *
+     * <p>
+     * HTTP: POST /collections/{collectionName}/documents/import
+     *
+     * @see <a href="https://typesense.org/docs/latest/api/documents.html">Typesense docs</a>
+     */
     public String import_(Collection<?> documents,
             ImportDocumentsParameters queryParameters) throws Exception {
         ObjectMapper mapper = new ObjectMapper();

--- a/src/main/java/org/typesense/api/FieldTypes.java
+++ b/src/main/java/org/typesense/api/FieldTypes.java
@@ -1,5 +1,8 @@
 package org.typesense.api;
 
+/**
+ * Typesense field types API wrapper.
+ */
 public final class FieldTypes {
     public static final String STRING = "string";
     public static final String INT32 = "int32";

--- a/src/main/java/org/typesense/api/Health.java
+++ b/src/main/java/org/typesense/api/Health.java
@@ -2,11 +2,18 @@ package org.typesense.api;
 
 import java.util.Map;
 
+/**
+ * Typesense health API wrapper.
+ */
 public class Health {
 
     private ApiCall apiCall;
     public static final String RESOURCEPATH = "/health";
 
+    /**
+     * Creates a new Health instance.
+     * @param apiCall the {@code ApiCall} instance used to send requests
+     */
     public Health(ApiCall apiCall) {
         this.apiCall = apiCall;
     }
@@ -16,6 +23,9 @@ public class Health {
      *
      * <p>
      * HTTP: GET /health
+     *
+     * @return the {@code Map<String,Object>} response map
+     * @throws Exception if the request fails
      *
      * @see <a href="https://typesense.org/docs/latest/api/cluster-operations.html#health">Typesense docs</a>
      */

--- a/src/main/java/org/typesense/api/Health.java
+++ b/src/main/java/org/typesense/api/Health.java
@@ -11,6 +11,14 @@ public class Health {
         this.apiCall = apiCall;
     }
 
+    /**
+     * Checks if Typesense server is ready to accept requests.
+     *
+     * <p>
+     * HTTP: GET /health
+     *
+     * @see <a href="https://typesense.org/docs/latest/api/cluster-operations.html#health">Typesense docs</a>
+     */
     public Map<String, Object> retrieve() throws Exception {
         return this.apiCall.get(RESOURCEPATH, null, Map.class);
     }

--- a/src/main/java/org/typesense/api/Key.java
+++ b/src/main/java/org/typesense/api/Key.java
@@ -2,11 +2,19 @@ package org.typesense.api;
 
 import org.typesense.model.ApiKey;
 
+/**
+ * Typesense key API wrapper.
+ */
 public class Key {
 
     private Long id;
     private ApiCall apiCall;
 
+    /**
+     * Creates a new Key instance.
+     * @param id the {@code Long} id
+     * @param apiCall the {@code ApiCall} instance used to send requests
+     */
     public Key(Long id, ApiCall apiCall) {
         this.id = id;
         this.apiCall = apiCall;
@@ -21,6 +29,9 @@ public class Key {
      * <p>
      * HTTP: GET /keys/{keyId}
      *
+     * @return the {@code ApiKey} response
+     * @throws Exception if the request fails
+     *
      * @see <a href="https://typesense.org/docs/latest/api/api-keys.html">Typesense docs</a>
      */
     public ApiKey retrieve() throws Exception {
@@ -32,6 +43,9 @@ public class Key {
      *
      * <p>
      * HTTP: DELETE /keys/{keyId}
+     *
+     * @return the {@code ApiKey} response
+     * @throws Exception if the request fails
      *
      * @see <a href="https://typesense.org/docs/latest/api/api-keys.html">Typesense docs</a>
      */

--- a/src/main/java/org/typesense/api/Key.java
+++ b/src/main/java/org/typesense/api/Key.java
@@ -12,10 +12,29 @@ public class Key {
         this.apiCall = apiCall;
     }
 
+    /**
+     * Retrieve (metadata about) a key.
+     *
+     * <p>
+     * Retrieve (metadata about) a key. Only the key prefix is returned when you retrieve a key. Due to security reasons, only the create endpoint returns the full API key.
+     *
+     * <p>
+     * HTTP: GET /keys/{keyId}
+     *
+     * @see <a href="https://typesense.org/docs/latest/api/api-keys.html">Typesense docs</a>
+     */
     public ApiKey retrieve() throws Exception {
         return this.apiCall.get(this.getEndpoint(), null, ApiKey.class);
     }
 
+    /**
+     * Delete an API key given its ID.
+     *
+     * <p>
+     * HTTP: DELETE /keys/{keyId}
+     *
+     * @see <a href="https://typesense.org/docs/latest/api/api-keys.html">Typesense docs</a>
+     */
     public ApiKey delete() throws Exception {
         return this.apiCall.delete(this.getEndpoint(), null, ApiKey.class);
     }

--- a/src/main/java/org/typesense/api/Keys.java
+++ b/src/main/java/org/typesense/api/Keys.java
@@ -21,6 +21,17 @@ public class Keys {
         this.apiCall = apiCall;
     }
 
+    /**
+     * Create an API Key.
+     *
+     * <p>
+     * Create an API Key with fine-grain access control. You can restrict access on both a per-collection and per-action level. The generated key is returned only during creation. You want to store this key carefully in a secure place.
+     *
+     * <p>
+     * HTTP: POST /keys
+     *
+     * @see <a href="https://typesense.org/docs/latest/api/api-keys.html">Typesense docs</a>
+     */
     public ApiKey create(ApiKeySchema apiKeySchema) throws Exception {
         if (apiKeySchema.getExpiresAt() == null) {
             apiKeySchema.setExpiresAt(System.currentTimeMillis() / 1000L + 315360000); // Adding 10 years for expiration.
@@ -28,6 +39,14 @@ public class Keys {
         return this.apiCall.post(Keys.RESOURCEPATH, apiKeySchema, null, ApiKey.class);
     }
 
+    /**
+     * Retrieve (metadata about) all keys.
+     *
+     * <p>
+     * HTTP: GET /keys
+     *
+     * @see <a href="https://typesense.org/docs/latest/api/api-keys.html">Typesense docs</a>
+     */
     public ApiKeysResponse retrieve() throws Exception {
         return this.apiCall.get(Keys.RESOURCEPATH, null, ApiKeysResponse.class);
     }

--- a/src/main/java/org/typesense/api/Keys.java
+++ b/src/main/java/org/typesense/api/Keys.java
@@ -12,11 +12,18 @@ import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.Map;
 
+/**
+ * Typesense keys API wrapper.
+ */
 public class Keys {
 
     public static final String RESOURCEPATH = "/keys";
     private ApiCall apiCall;
 
+    /**
+     * Creates a new Keys instance.
+     * @param apiCall the {@code ApiCall} instance used to send requests
+     */
     public Keys(ApiCall apiCall) {
         this.apiCall = apiCall;
     }
@@ -29,6 +36,10 @@ public class Keys {
      *
      * <p>
      * HTTP: POST /keys
+     *
+     * @param apiKeySchema the {@code ApiKeySchema} request body
+     * @return the {@code ApiKey} response
+     * @throws Exception if the request fails
      *
      * @see <a href="https://typesense.org/docs/latest/api/api-keys.html">Typesense docs</a>
      */
@@ -44,6 +55,9 @@ public class Keys {
      *
      * <p>
      * HTTP: GET /keys
+     *
+     * @return the {@code ApiKeysResponse} response
+     * @throws Exception if the request fails
      *
      * @see <a href="https://typesense.org/docs/latest/api/api-keys.html">Typesense docs</a>
      */

--- a/src/main/java/org/typesense/api/Metrics.java
+++ b/src/main/java/org/typesense/api/Metrics.java
@@ -2,11 +2,18 @@ package org.typesense.api;
 
 import java.util.Map;
 
+/**
+ * Typesense metrics API wrapper.
+ */
 public class Metrics {
 
     private ApiCall apiCall;
     public static final String RESOURCEPATH = "/metrics.json";
 
+    /**
+     * Creates a new Metrics instance.
+     * @param apiCall the {@code ApiCall} instance used to send requests
+     */
     public Metrics(ApiCall apiCall) {
         this.apiCall = apiCall;
     }
@@ -19,6 +26,9 @@ public class Metrics {
      *
      * <p>
      * HTTP: GET /metrics.json
+     *
+     * @return the {@code Map<String,String>} response map
+     * @throws Exception if the request fails
      *
      * @see <a href="https://typesense.org/docs/latest/api/cluster-operations.html">Typesense docs</a>
      */

--- a/src/main/java/org/typesense/api/Metrics.java
+++ b/src/main/java/org/typesense/api/Metrics.java
@@ -11,6 +11,17 @@ public class Metrics {
         this.apiCall = apiCall;
     }
 
+    /**
+     * Get current RAM, CPU, Disk and Network usage metrics.
+     *
+     * <p>
+     * Retrieve the metrics.
+     *
+     * <p>
+     * HTTP: GET /metrics.json
+     *
+     * @see <a href="https://typesense.org/docs/latest/api/cluster-operations.html">Typesense docs</a>
+     */
     public Map<String, String> retrieve() throws Exception {
         return this.apiCall.get(RESOURCEPATH, null, Map.class);
     }

--- a/src/main/java/org/typesense/api/MultiSearch.java
+++ b/src/main/java/org/typesense/api/MultiSearch.java
@@ -6,11 +6,18 @@ import org.typesense.model.MultiSearchSearchesParameter;
 
 import java.util.Map;
 
+/**
+ * Typesense multi search API wrapper.
+ */
 public class MultiSearch {
 
     private ApiCall apiCall;
     public static final String RESOURCEPATH = "/multi_search";
 
+    /**
+     * Creates a new MultiSearch instance.
+     * @param apiCall the {@code ApiCall} instance used to send requests
+     */
     public MultiSearch(ApiCall apiCall) {
         this.apiCall = apiCall;
     }

--- a/src/main/java/org/typesense/api/Operations.java
+++ b/src/main/java/org/typesense/api/Operations.java
@@ -2,11 +2,18 @@ package org.typesense.api;
 
 import java.util.Map;
 
+/**
+ * Typesense operations API wrapper.
+ */
 public class Operations {
 
     private ApiCall apiCall;
     public static final String RESOUCEPATH = "/operations";
 
+    /**
+     * Creates a new Operations instance.
+     * @param apiCall the {@code ApiCall} instance used to send requests
+     */
     public Operations(ApiCall apiCall) {
         this.apiCall = apiCall;
     }

--- a/src/main/java/org/typesense/api/Stemming.java
+++ b/src/main/java/org/typesense/api/Stemming.java
@@ -3,12 +3,19 @@ package org.typesense.api;
 import java.util.HashMap;
 import java.util.Map;
 
+/**
+ * Typesense stemming API wrapper.
+ */
 public class Stemming {
     private final ApiCall apiCall;
     private final StemmingDictionaries dictionaries;
     private final Map<String, StemmingDictionary> individualDictionaries;
 
 
+    /**
+     * Creates a new Stemming instance.
+     * @param apiCall the {@code ApiCall} instance used to send requests
+     */
     public Stemming(ApiCall apiCall) {
         this.apiCall = apiCall;
         this.dictionaries = new StemmingDictionaries(this.apiCall);

--- a/src/main/java/org/typesense/api/StemmingDictionaries.java
+++ b/src/main/java/org/typesense/api/StemmingDictionaries.java
@@ -17,12 +17,34 @@ public class StemmingDictionaries {
         this.apiCall = apiCall;
     }
 
+    /**
+     * Import a stemming dictionary.
+     *
+     * <p>
+     * Upload a JSONL file containing word mappings to create or update a stemming dictionary.
+     *
+     * <p>
+     * HTTP: POST /stemming/dictionaries/import
+     *
+     * @see <a href="https://typesense.org/docs/latest/api/stemming.html">Typesense docs</a>
+     */
     public String upsert(String dictionaryId, String wordRootCombinations) throws Exception {
         Map<String, String> params = Collections.singletonMap("id", dictionaryId);
 
         return this.apiCall.post(this.getEndPoint("import"), wordRootCombinations, params, String.class);
     }
 
+    /**
+     * Import a stemming dictionary.
+     *
+     * <p>
+     * Upload a JSONL file containing word mappings to create or update a stemming dictionary.
+     *
+     * <p>
+     * HTTP: POST /stemming/dictionaries/import
+     *
+     * @see <a href="https://typesense.org/docs/latest/api/stemming.html">Typesense docs</a>
+     */
     public List<StemmingDictionaryWords> upsert(String dictionaryId, List<StemmingDictionaryWords> wordRootCombinations)
             throws Exception {
         ObjectMapper mapper = new ObjectMapper();
@@ -46,6 +68,17 @@ public class StemmingDictionaries {
         return objectList;
     }
 
+    /**
+     * List all stemming dictionaries.
+     *
+     * <p>
+     * Retrieve a list of all available stemming dictionaries.
+     *
+     * <p>
+     * HTTP: GET /stemming/dictionaries
+     *
+     * @see <a href="https://typesense.org/docs/latest/api/stemming.html">Typesense docs</a>
+     */
     public StemmingDictionariesRetrieveSchema retrieve() throws Exception {
         StemmingDictionariesRetrieveSchema response = this.apiCall.get(RESOURCE_PATH, null,
                 StemmingDictionariesRetrieveSchema.class);

--- a/src/main/java/org/typesense/api/StemmingDictionaries.java
+++ b/src/main/java/org/typesense/api/StemmingDictionaries.java
@@ -9,10 +9,17 @@ import org.typesense.model.StemmingDictionaryWords;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+/**
+ * Typesense stemming dictionaries API wrapper.
+ */
 public class StemmingDictionaries {
     private final ApiCall apiCall;
     public final static String RESOURCE_PATH = "/stemming/dictionaries";
 
+    /**
+     * Creates a new StemmingDictionaries instance.
+     * @param apiCall the {@code ApiCall} instance used to send requests
+     */
     public StemmingDictionaries(ApiCall apiCall) {
         this.apiCall = apiCall;
     }
@@ -25,6 +32,11 @@ public class StemmingDictionaries {
      *
      * <p>
      * HTTP: POST /stemming/dictionaries/import
+     *
+     * @param dictionaryId the {@code String} dictionary id
+     * @param wordRootCombinations the {@code String} request body
+     * @return the raw response body
+     * @throws Exception if the request fails
      *
      * @see <a href="https://typesense.org/docs/latest/api/stemming.html">Typesense docs</a>
      */
@@ -42,6 +54,11 @@ public class StemmingDictionaries {
      *
      * <p>
      * HTTP: POST /stemming/dictionaries/import
+     *
+     * @param dictionaryId the {@code String} dictionary id
+     * @param wordRootCombinations the {@code List<StemmingDictionaryWords>} word root combinations
+     * @return the {@code List<StemmingDictionaryWords>} response
+     * @throws Exception if the request fails
      *
      * @see <a href="https://typesense.org/docs/latest/api/stemming.html">Typesense docs</a>
      */
@@ -76,6 +93,9 @@ public class StemmingDictionaries {
      *
      * <p>
      * HTTP: GET /stemming/dictionaries
+     *
+     * @return the {@code StemmingDictionariesRetrieveSchema} response
+     * @throws Exception if the request fails
      *
      * @see <a href="https://typesense.org/docs/latest/api/stemming.html">Typesense docs</a>
      */

--- a/src/main/java/org/typesense/api/StemmingDictionariesRetrieveSchema.java
+++ b/src/main/java/org/typesense/api/StemmingDictionariesRetrieveSchema.java
@@ -2,6 +2,9 @@ package org.typesense.api;
 
 import java.util.List;
 
+/**
+ * Typesense stemming dictionaries retrieve schema API wrapper.
+ */
 public class StemmingDictionariesRetrieveSchema {
     private List<String> dictionaries;
 

--- a/src/main/java/org/typesense/api/StemmingDictionary.java
+++ b/src/main/java/org/typesense/api/StemmingDictionary.java
@@ -2,10 +2,18 @@ package org.typesense.api;
 
 import org.typesense.api.utils.URLEncoding;
 
+/**
+ * Typesense stemming dictionary API wrapper.
+ */
 public class StemmingDictionary {
     private final ApiCall apiCall;
     private final String dictionaryId;
 
+    /**
+     * Creates a new StemmingDictionary instance.
+     * @param dictionaryId the {@code String} path parameter
+     * @param apiCall the {@code ApiCall} instance used to send requests
+     */
     public StemmingDictionary(String dictionaryId, ApiCall apiCall) {
         this.apiCall = apiCall;
         this.dictionaryId = dictionaryId;
@@ -20,6 +28,9 @@ public class StemmingDictionary {
      *
      * <p>
      * HTTP: GET /stemming/dictionaries/{dictionaryId}
+     *
+     * @return the {@code org.typesense.model.StemmingDictionary} response
+     * @throws Exception if the request fails
      *
      * @see <a href="https://typesense.org/docs/latest/api/stemming.html">Typesense docs</a>
      */

--- a/src/main/java/org/typesense/api/StemmingDictionary.java
+++ b/src/main/java/org/typesense/api/StemmingDictionary.java
@@ -12,6 +12,17 @@ public class StemmingDictionary {
     }
 
 
+    /**
+     * Retrieve a stemming dictionary.
+     *
+     * <p>
+     * Fetch details of a specific stemming dictionary.
+     *
+     * <p>
+     * HTTP: GET /stemming/dictionaries/{dictionaryId}
+     *
+     * @see <a href="https://typesense.org/docs/latest/api/stemming.html">Typesense docs</a>
+     */
     public org.typesense.model.StemmingDictionary retrieve() throws Exception {
         return this.apiCall.get(this.getEndpoint(), null, org.typesense.model.StemmingDictionary.class);
     }

--- a/src/main/java/org/typesense/api/Stopwords.java
+++ b/src/main/java/org/typesense/api/Stopwords.java
@@ -14,10 +14,32 @@ public class Stopwords {
         this.apiCall = apiCall;
     }
 
+    /**
+     * Upserts a stopwords set.
+     *
+     * <p>
+     * When an analytics rule is created, we give it a name and describe the type, the source collections and the destination collection.
+     *
+     * <p>
+     * HTTP: PUT /stopwords/{setId}
+     *
+     * @see <a href="https://typesense.org/docs/latest/api/stopwords.html">Typesense docs</a>
+     */
     public StopwordsSetSchema upsert(String stopwordSetId, StopwordsSetUpsertSchema stopwordSet) throws Exception {
         return this.apiCall.put(getEndpoint(stopwordSetId), stopwordSet, null, StopwordsSetSchema.class);
     }
 
+    /**
+     * Retrieves all stopwords sets.
+     *
+     * <p>
+     * Retrieve the details of all stopwords sets
+     *
+     * <p>
+     * HTTP: GET /stopwords
+     *
+     * @see <a href="https://typesense.org/docs/latest/api/stopwords.html">Typesense docs</a>
+     */
     public StopwordsSetsRetrieveAllSchema retrieve() throws Exception {
         return this.apiCall.get(Stopwords.RESOURCEPATH, null, StopwordsSetsRetrieveAllSchema.class);
     }

--- a/src/main/java/org/typesense/api/Stopwords.java
+++ b/src/main/java/org/typesense/api/Stopwords.java
@@ -5,11 +5,18 @@ import org.typesense.model.StopwordsSetSchema;
 import org.typesense.model.StopwordsSetUpsertSchema;
 import org.typesense.model.StopwordsSetsRetrieveAllSchema;
 
+/**
+ * Typesense stopwords API wrapper.
+ */
 public class Stopwords {
     public final static String RESOURCEPATH = "/stopwords";
 
     private final ApiCall apiCall;
 
+    /**
+     * Creates a new Stopwords instance.
+     * @param apiCall the {@code ApiCall} instance used to send requests
+     */
     public Stopwords(ApiCall apiCall) {
         this.apiCall = apiCall;
     }
@@ -22,6 +29,11 @@ public class Stopwords {
      *
      * <p>
      * HTTP: PUT /stopwords/{setId}
+     *
+     * @param stopwordSetId the {@code String} path parameter
+     * @param stopwordSet the {@code StopwordsSetUpsertSchema} request body
+     * @return the {@code StopwordsSetSchema} response
+     * @throws Exception if the request fails
      *
      * @see <a href="https://typesense.org/docs/latest/api/stopwords.html">Typesense docs</a>
      */
@@ -37,6 +49,9 @@ public class Stopwords {
      *
      * <p>
      * HTTP: GET /stopwords
+     *
+     * @return the {@code StopwordsSetsRetrieveAllSchema} response
+     * @throws Exception if the request fails
      *
      * @see <a href="https://typesense.org/docs/latest/api/stopwords.html">Typesense docs</a>
      */

--- a/src/main/java/org/typesense/api/StopwordsSet.java
+++ b/src/main/java/org/typesense/api/StopwordsSet.java
@@ -4,10 +4,18 @@ import org.typesense.api.utils.URLEncoding;
 import org.typesense.model.StopwordsSetRetrieveSchema;
 import org.typesense.model.StopwordsSetSchema;
 
+/**
+ * Typesense stopwords set API wrapper.
+ */
 public class StopwordsSet {
     private final ApiCall apiCall;
     private final String stopwordsSetId;
 
+    /**
+     * Creates a new StopwordsSet instance.
+     * @param stopwordsSetId the {@code String} path parameter
+     * @param apiCall the {@code ApiCall} instance used to send requests
+     */
     public StopwordsSet(String stopwordsSetId, ApiCall apiCall) {
         this.stopwordsSetId = stopwordsSetId;
         this.apiCall = apiCall;
@@ -21,6 +29,9 @@ public class StopwordsSet {
      *
      * <p>
      * HTTP: GET /stopwords/{setId}
+     *
+     * @return the {@code StopwordsSetRetrieveSchema} response
+     * @throws Exception if the request fails
      *
      * @see <a href="https://typesense.org/docs/latest/api/stopwords.html">Typesense docs</a>
      */
@@ -36,6 +47,9 @@ public class StopwordsSet {
      *
      * <p>
      * HTTP: DELETE /stopwords/{setId}
+     *
+     * @return the {@code StopwordsSetSchema} response
+     * @throws Exception if the request fails
      *
      * @see <a href="https://typesense.org/docs/latest/api/stopwords.html">Typesense docs</a>
      */

--- a/src/main/java/org/typesense/api/StopwordsSet.java
+++ b/src/main/java/org/typesense/api/StopwordsSet.java
@@ -13,10 +13,32 @@ public class StopwordsSet {
         this.apiCall = apiCall;
     }
 
+    /**
+     * Retrieves a stopwords set.
+     *
+     * <p>
+     * Retrieve the details of a stopwords set, given it's name.
+     *
+     * <p>
+     * HTTP: GET /stopwords/{setId}
+     *
+     * @see <a href="https://typesense.org/docs/latest/api/stopwords.html">Typesense docs</a>
+     */
     public StopwordsSetRetrieveSchema retrieve() throws Exception {
         return this.apiCall.get(this.getEndpoint(), null, StopwordsSetRetrieveSchema.class);
     }
 
+    /**
+     * Delete a stopwords set.
+     *
+     * <p>
+     * Permanently deletes a stopwords set, given it's name.
+     *
+     * <p>
+     * HTTP: DELETE /stopwords/{setId}
+     *
+     * @see <a href="https://typesense.org/docs/latest/api/stopwords.html">Typesense docs</a>
+     */
     public StopwordsSetSchema delete() throws Exception {
         return this.apiCall.delete(this.getEndpoint(), null, StopwordsSetSchema.class);
     }

--- a/src/main/java/org/typesense/api/Synonym.java
+++ b/src/main/java/org/typesense/api/Synonym.java
@@ -18,6 +18,12 @@ public class Synonym {
     private String synonymId;
     private ApiCall apiCall;
 
+    /**
+     * Creates a new Synonym instance.
+     * @param collectionName the {@code String} path parameter
+     * @param synonymId the {@code String} path parameter
+     * @param apiCall the {@code ApiCall} instance used to send requests
+     */
     public Synonym(String collectionName, String synonymId, ApiCall apiCall) {
         this.collectionName = collectionName;
         this.synonymId = synonymId;

--- a/src/main/java/org/typesense/api/SynonymSet.java
+++ b/src/main/java/org/typesense/api/SynonymSet.java
@@ -6,11 +6,19 @@ import org.typesense.model.SynonymSetCreateSchema;
 import org.typesense.model.SynonymSetSchema;
 import org.typesense.model.SynonymSetDeleteSchema;
 
+/**
+ * Typesense synonym set API wrapper.
+ */
 public class SynonymSet {
 
     private String synonymSetName;
     private ApiCall apiCall;
 
+    /**
+     * Creates a new SynonymSet instance.
+     * @param synonymSetName the {@code String} path parameter
+     * @param apiCall the {@code ApiCall} instance used to send requests
+     */
     public SynonymSet(String synonymSetName, ApiCall apiCall) {
         this.synonymSetName = synonymSetName;
         this.apiCall = apiCall;
@@ -24,6 +32,9 @@ public class SynonymSet {
      *
      * <p>
      * HTTP: GET /synonym_sets/{synonymSetName}
+     *
+     * @return the {@code SynonymSetCreateSchema} response
+     * @throws Exception if the request fails
      *
      * @see <a href="https://typesense.org/docs/latest/api/synonyms.html">Typesense docs</a>
      */
@@ -40,6 +51,10 @@ public class SynonymSet {
      * <p>
      * HTTP: PUT /synonym_sets/{synonymSetName}
      *
+     * @param synonymSetCreateSchema the {@code SynonymSetCreateSchema} request body
+     * @return the {@code SynonymSetSchema} response
+     * @throws Exception if the request fails
+     *
      * @see <a href="https://typesense.org/docs/latest/api/synonyms.html">Typesense docs</a>
      */
     public SynonymSetSchema upsert(SynonymSetCreateSchema synonymSetCreateSchema) throws Exception {
@@ -54,6 +69,9 @@ public class SynonymSet {
      *
      * <p>
      * HTTP: DELETE /synonym_sets/{synonymSetName}
+     *
+     * @return the {@code SynonymSetDeleteSchema} response
+     * @throws Exception if the request fails
      *
      * @see <a href="https://typesense.org/docs/latest/api/synonyms.html">Typesense docs</a>
      */

--- a/src/main/java/org/typesense/api/SynonymSet.java
+++ b/src/main/java/org/typesense/api/SynonymSet.java
@@ -16,14 +16,47 @@ public class SynonymSet {
         this.apiCall = apiCall;
     }
 
+    /**
+     * Retrieve a synonym set.
+     *
+     * <p>
+     * Retrieve a specific synonym set by its name
+     *
+     * <p>
+     * HTTP: GET /synonym_sets/{synonymSetName}
+     *
+     * @see <a href="https://typesense.org/docs/latest/api/synonyms.html">Typesense docs</a>
+     */
     public SynonymSetCreateSchema retrieve() throws Exception {
         return this.apiCall.get(this.getEndpoint(), null, SynonymSetCreateSchema.class);
     }
 
+    /**
+     * Create or update a synonym set.
+     *
+     * <p>
+     * Create or update a synonym set with the given name
+     *
+     * <p>
+     * HTTP: PUT /synonym_sets/{synonymSetName}
+     *
+     * @see <a href="https://typesense.org/docs/latest/api/synonyms.html">Typesense docs</a>
+     */
     public SynonymSetSchema upsert(SynonymSetCreateSchema synonymSetCreateSchema) throws Exception {
         return this.apiCall.put(this.getEndpoint(), synonymSetCreateSchema, null, SynonymSetSchema.class);
     }
 
+    /**
+     * Delete a synonym set.
+     *
+     * <p>
+     * Delete a specific synonym set by its name
+     *
+     * <p>
+     * HTTP: DELETE /synonym_sets/{synonymSetName}
+     *
+     * @see <a href="https://typesense.org/docs/latest/api/synonyms.html">Typesense docs</a>
+     */
     public SynonymSetDeleteSchema delete() throws Exception {
         return this.apiCall.delete(this.getEndpoint(), null, SynonymSetDeleteSchema.class);
     }

--- a/src/main/java/org/typesense/api/SynonymSets.java
+++ b/src/main/java/org/typesense/api/SynonymSets.java
@@ -13,10 +13,32 @@ public class SynonymSets {
         this.apiCall = apiCall;
     }
 
+    /**
+     * Create or update a synonym set.
+     *
+     * <p>
+     * Create or update a synonym set with the given name
+     *
+     * <p>
+     * HTTP: PUT /synonym_sets/{synonymSetName}
+     *
+     * @see <a href="https://typesense.org/docs/latest/api/synonyms.html">Typesense docs</a>
+     */
     public SynonymSetSchema upsert(String synonymSetName, SynonymSetCreateSchema synonymSetCreateSchema) throws Exception {
         return this.apiCall.put(getEndpoint(synonymSetName), synonymSetCreateSchema, null, SynonymSetSchema.class);
     }
 
+    /**
+     * Retrieve a synonym set.
+     *
+     * <p>
+     * Retrieve a specific synonym set by its name
+     *
+     * <p>
+     * HTTP: GET /synonym_sets/{synonymSetName}
+     *
+     * @see <a href="https://typesense.org/docs/latest/api/synonyms.html">Typesense docs</a>
+     */
     public SynonymSetSchema[] retrieve() throws Exception {
         return this.apiCall.get(this.getEndpoint(null), null, SynonymSetSchema[].class);
     }

--- a/src/main/java/org/typesense/api/SynonymSets.java
+++ b/src/main/java/org/typesense/api/SynonymSets.java
@@ -4,11 +4,18 @@ import java.util.List;
 import org.typesense.model.SynonymSetCreateSchema;
 import org.typesense.model.SynonymSetSchema;
 
+/**
+ * Typesense synonym sets API wrapper.
+ */
 public class SynonymSets {
 
     private ApiCall apiCall;
     public final static String RESOURCEPATH = "/synonym_sets";
 
+    /**
+     * Creates a new SynonymSets instance.
+     * @param apiCall the {@code ApiCall} instance used to send requests
+     */
     public SynonymSets(ApiCall apiCall) {
         this.apiCall = apiCall;
     }
@@ -21,6 +28,11 @@ public class SynonymSets {
      *
      * <p>
      * HTTP: PUT /synonym_sets/{synonymSetName}
+     *
+     * @param synonymSetName the {@code String} path parameter
+     * @param synonymSetCreateSchema the {@code SynonymSetCreateSchema} request body
+     * @return the {@code SynonymSetSchema} response
+     * @throws Exception if the request fails
      *
      * @see <a href="https://typesense.org/docs/latest/api/synonyms.html">Typesense docs</a>
      */
@@ -36,6 +48,9 @@ public class SynonymSets {
      *
      * <p>
      * HTTP: GET /synonym_sets/{synonymSetName}
+     *
+     * @return the {@code SynonymSetSchema[]} response array
+     * @throws Exception if the request fails
      *
      * @see <a href="https://typesense.org/docs/latest/api/synonyms.html">Typesense docs</a>
      */

--- a/src/main/java/org/typesense/api/Synonyms.java
+++ b/src/main/java/org/typesense/api/Synonyms.java
@@ -20,6 +20,11 @@ public class Synonyms {
     private ApiCall apiCall;
     public final static String RESOURCEPATH = "/synonyms";
 
+    /**
+     * Creates a new Synonyms instance.
+     * @param collectionName the {@code String} path parameter
+     * @param apiCall the {@code ApiCall} instance used to send requests
+     */
     public Synonyms(String collectionName, ApiCall apiCall) {
         this.collectionName = collectionName;
         this.apiCall = apiCall;


### PR DESCRIPTION
## Change Summary


- add docgen generator tool for automating javadoc generation
- generate javadocs for API classes with method descriptions, HTTP endpoints, and typesense docs links
- add nix flake for development environment setup

## PR Checklist
<!--- Put an `x` inside the box : -->
- [ ] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
